### PR TITLE
Fix getter of debug setting and type annotations of port settings

### DIFF
--- a/packages/common/src/config/services/ServerSettingsService.ts
+++ b/packages/common/src/config/services/ServerSettingsService.ts
@@ -162,7 +162,7 @@ export class ServerSettingsService extends DIConfiguration {
   }
 
   get debug(): boolean {
-    return this.logger.level === "info";
+    return this.logger.level === "debug";
   }
 
   set debug(debug: boolean) {

--- a/packages/common/src/config/services/ServerSettingsService.ts
+++ b/packages/common/src/config/services/ServerSettingsService.ts
@@ -63,11 +63,11 @@ export class ServerSettingsService extends DIConfiguration {
     this.setRaw("rootDir", value);
   }
 
-  get port(): string | number {
+  get port(): string | number | false {
     return this.httpPort;
   }
 
-  set port(value: string | number) {
+  set port(value: string | number | false) {
     this.httpPort = value;
   }
 
@@ -79,19 +79,19 @@ export class ServerSettingsService extends DIConfiguration {
     this.setRaw("httpsOptions", value);
   }
 
-  get httpPort(): string | number {
+  get httpPort(): string | number | false {
     return this.getRaw("httpPort");
   }
 
-  set httpPort(value: string | number) {
+  set httpPort(value: string | number | false) {
     this.setRaw("httpPort", value);
   }
 
-  get httpsPort(): string | number {
+  get httpsPort(): string | number | false {
     return this.getRaw("httpsPort");
   }
 
-  set httpsPort(value: string | number) {
+  set httpsPort(value: string | number | false) {
     this.setRaw("httpsPort", value);
   }
 

--- a/packages/common/test/config/services/ServerSettingsService.spec.ts
+++ b/packages/common/test/config/services/ServerSettingsService.spec.ts
@@ -114,12 +114,15 @@ describe("ServerSettingsService", () => {
       expect(settings.statics).to.deep.equal({"/": "/publics"});
     });
 
-    it("should return debug", () => {
-      expect(settings.debug).to.equal(false);
-    });
+    describe("debug", () => {
+      it("should expose debug as initialized", () => {
+        expect(settings.debug).to.equal(true);
+      });
 
-    it("should return debug (2)", () => {
-      expect(settings.debug).to.equal(false);
+      it(".debug should be equal to the last set value", () => {
+        settings.debug = false;
+        expect(settings.debug).to.equal(false);
+      });
     });
 
     it("should return env", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "strict": true,
     "baseUrl": ".",
     "paths": {
       "@tsed/*": [


### PR DESCRIPTION


Type | Breaking change
---|---
Fix|Yes
****

## Description
Since `httpPort` and `httpsPort` can be `false` (to disable the respective protocol), I propose adding `false` to the untagged union type of those properties (and the `httpPort` synonym port). The setter and getter of settings.debug disagreed, so I propose changing the getter to return true iff the log level is `"debug"`.

## Retrospective
Automate type checking to improve the quality of the type annotations.

