### PR TITLE
[BUGFIX/GRAPHQL/URGENT] dataSources needs to be instantiated each apollo request

### DIFF
--- a/packages/graphql/src/services/GraphQLService.ts
+++ b/packages/graphql/src/services/GraphQLService.ts
@@ -156,9 +156,9 @@ export class GraphQLService {
    * @param serverConfigSources
    */
   protected createDataSources(dataSources: Function | undefined, serverConfigSources: Function | undefined) {
-    const sources = this.getDataSources();
-
     return () => {
+      const sources = this.getDataSources();
+
       return {
         ...sources,
         ...(dataSources ? dataSources() : {}),


### PR DESCRIPTION
the createDatasources is executed once in the server config, the getDatasources needs to be provider scope instance per request. It needs to be inside the factory call or else the internal caching mechanism of RestDataSource will not be properly flushed and cause a memory leak.
