### PR TITLE
feature(common): add converter settings and converter additional prop…

### DIFF
--- a/docs/docs/converters.md
+++ b/docs/docs/converters.md
@@ -261,3 +261,30 @@ console.log(result) // TaskModel {unknownProperty: "test"}
 If you have disabled `strict` validation at the global level, you can use the `@ModelStrict(true)` decorator
 to enable validation for a specific model.
 :::
+
+### Converter AdditionalProperty Policy
+
+```typescript
+import {ServerLoader, ServerSettings} from "@tsed/common";
+
+@ServerSettings({
+    converter: {
+        additionalProperty: "error" | "accept" | "ignore"
+    }
+})
+export class Server extends ServerLoader {
+   
+}      
+```
+AdditionalProperty define the policy to adopt if the JSON object contains one more field than expected in the model.
+
+- "error" Throw an error. Equal to `validationModelStrict: true`.
+- "accept" Return original JSON object with additional properties `validationModelStrict: false`.
+- "ignore" Remove all additional properties that not defined in the model.
+
+::: Note
+`additionalProperty` setting override `validationModelStrict` and is overrided by `@ModelStrict`.
+:::
+
+
+

--- a/packages/common/src/config/interfaces/IConverterSettings.ts
+++ b/packages/common/src/config/interfaces/IConverterSettings.ts
@@ -1,0 +1,6 @@
+export interface IConverterSettings {
+  /**
+   * TODO: additionalProperty description
+   */
+  additionalProperty?: "error" | "accept" | "ignore";
+}

--- a/packages/common/src/config/interfaces/IConverterSettings.ts
+++ b/packages/common/src/config/interfaces/IConverterSettings.ts
@@ -1,6 +1,7 @@
 export interface IConverterSettings {
   /**
-   * TODO: additionalProperty description
+   * Converter additional property policy. (see [Converters](/docs/converters.md))
+   *
    */
   additionalProperty?: "error" | "accept" | "ignore";
 }

--- a/packages/common/src/config/interfaces/index.ts
+++ b/packages/common/src/config/interfaces/index.ts
@@ -5,6 +5,7 @@ import {IErrorsSettings} from "./IErrorSettings";
 import {ILoggerSettings} from "./ILoggerSettings";
 import {IRouterSettings} from "./IRouterSettings";
 import {IServerMountDirectories} from "./IServerMountDirectories";
+import {IConverterSettings} from "./IConverterSettings";
 
 declare global {
   namespace TsED {
@@ -69,8 +70,14 @@ declare global {
        * Use a strict validation when a model is used by the converter.
        * When a property is unknown, it throw a `BadRequest` (see [Converters](/docs/converters.md)).
        * By default true.
+       *
+       * @deprecated Use converter.additionalProperty
        */
       validationModelStrict: boolean;
+      /**
+       * Converter configuration.
+       */
+      converter: Partial<IConverterSettings>;
       /**
        * Logger configuration.
        */

--- a/packages/common/src/config/services/ServerSettingsService.spec.ts
+++ b/packages/common/src/config/services/ServerSettingsService.spec.ts
@@ -150,6 +150,10 @@ describe("ServerSettingsService", () => {
       expect(settings.routers).to.deep.equal({mergeParams: true});
     });
 
+    it("should return converter settings", () => {
+      expect(settings.converter).to.deep.equal({});
+    });
+
     it("should return controllerScope", () => {
       expect(settings.controllerScope).to.equal("singleton");
     });

--- a/packages/common/src/config/services/ServerSettingsService.spec.ts
+++ b/packages/common/src/config/services/ServerSettingsService.spec.ts
@@ -53,6 +53,7 @@ describe("ServerSettingsService", () => {
       settings.routers = {mergeParams: true};
       settings.exclude = ["./**/*.spec.ts"];
       settings.debug = true;
+      settings.converter = {};
 
       settings.setHttpPort({address: "address", port: 8081});
       settings.setHttpsPort({address: "address", port: 8080});

--- a/packages/common/src/config/services/ServerSettingsService.ts
+++ b/packages/common/src/config/services/ServerSettingsService.ts
@@ -3,6 +3,7 @@ import {DIConfiguration, Injectable, ProviderScope, ProviderType} from "@tsed/di
 import {$log} from "@tsed/logger";
 import * as Https from "https";
 import {IErrorsSettings, ILoggerSettings, IRouterSettings, IServerMountDirectories} from "../interfaces";
+import {IConverterSettings} from "../interfaces/IConverterSettings";
 
 const rootDir = process.cwd();
 
@@ -185,6 +186,14 @@ export class ServerSettingsService extends DIConfiguration {
 
   set validationModelStrict(value: boolean) {
     this.setRaw("validationModelStrict", value);
+  }
+
+  get converter(): Partial<IConverterSettings> {
+    return this.get("converter") || {};
+  }
+
+  set converter(options: Partial<IConverterSettings>) {
+    this.setRaw("converter", options);
   }
 
   get logger(): Partial<ILoggerSettings> {

--- a/packages/common/src/converters/services/ConverterService.ts
+++ b/packages/common/src/converters/services/ConverterService.ts
@@ -293,16 +293,10 @@ export class ConverterService {
    */
   private skipAdditionalProperty(instance: any, propertyKey: string | symbol, propertyMetadata: PropertyMetadata | undefined) {
     if (propertyMetadata !== undefined) {
-      return false;
+      return false; // Property isn't an additional property
     }
 
-    let additionalPropertyLevel = this.getAdditionalPropertyLevel();
-
-    if (getClass(instance) !== Object) {
-      if (Store.from(getClass(instance)).has("modelStrict")) {
-        additionalPropertyLevel = !!Store.from(getClass(instance)).get("modelStrict") ? "error" : "accept";
-      }
-    }
+    const additionalPropertyLevel = this.getAdditionalPropertyLevel(getClass(instance));
 
     switch (additionalPropertyLevel) {
       case "error":
@@ -318,27 +312,22 @@ export class ConverterService {
   /**
    *
    * @param {Type<any>} target
-   * @returns {boolean}
-   */
-  private isStrictModelValidation(target: Type<any>): boolean {
-    if (target !== Object) {
-      const modelStrict = Store.from(target).get("modelStrict");
-
-      if (this.validationModelStrict) {
-        return modelStrict === undefined ? true : modelStrict;
-      } else {
-        return modelStrict === true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   *
    * @returns {"error" | "accept" | "ignore"}
    */
-  private getAdditionalPropertyLevel() {
-    return this.converterSettings.additionalProperty || this.validationModelStrict ? "error" : "accept";
+  private getAdditionalPropertyLevel(target: Type<any>) {
+    if (target !== Object) {
+      if (Store.from(target).has("modelStrict")) {
+        const modelStrict = Store.from(target).get("modelStrict");
+
+        return modelStrict === undefined || modelStrict ? "error" : "accept";
+      }
+      if (this.converterSettings.additionalProperty !== undefined) {
+        return this.converterSettings.additionalProperty;
+      }
+
+      return this.validationModelStrict ? "error" : "accept";
+    }
+
+    return "accept";
   }
 }


### PR DESCRIPTION
…erty policy options

<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Breaking change
---|---
Feature | Yes

****

## Description
Defined converter additional property policy in server settings.

## Usage example

```js
@ServerSettings({
    converter: {
         additionalProperty: "ignore" // 'error' || 'accept' || 'ignore'
    }
})
export class Server extends ServerLoader {

}

```
| field | type |override | values |
|-------|-------|----------|--------------------------------|
| **validationModelStrict** (default) |  option |          | true =>"error", false =>"accept" (default) |
| **converter.additionalProperties** | option | validationModelStrict  | "error", "accept", "ignore"|
|  **ModelStrict** | decorator |  validationModelStrict and converter.additionalProperty | true =>"error", false =>"accept" |

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation (Poor documentation with bad english)
