### PR TITLE
Fix typings path ("@tsed/swagger")

### DIFF
--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -3,7 +3,7 @@
   "version": "5.60.6",
   "description": "Swagger package for Ts.ED framework",
   "main": "./lib/index.js",
-  "typings": "./lib/index.ts",
+  "typings": "./lib/index.d.ts",
   "scripts": {
     "build": "tsc --build tsconfig.compile.json",
     "build:doc": "tsc --build tsconfig.doc.json"


### PR DESCRIPTION
## Informations
Fix

****

## Description

Package "@tsed/swagger"

The typings file name is wrongly pointing to `./lib/index.ts` (which does not exists) creating a tsc compilation error

```
error TS7016: Could not find a declaration file for module '@tsed/swagger'. '..../node_modules/@tsed/swagger/lib/index.js' implicitly has an 'any' type.
  Try `npm install @types/tsed__swagger` if it exists or add a new declaration (.d.ts) file containing `declare module '@tsed/swagger';`

3 import {Description, Example} from "@tsed/swagger";
```

