### PR TITLE
fix(platform-test-utils): replace \n with EOL in response matching

### DIFF
--- a/packages/platform-test-utils/src/tests/testView.ts
+++ b/packages/platform-test-utils/src/tests/testView.ts
@@ -3,6 +3,7 @@ import {Locals} from "@tsed/common/src/mvc/decorators/params/locals";
 import {expect} from "chai";
 import * as SuperTest from "supertest";
 import {PlatformTestOptions} from "../interfaces";
+import {EOL} from "os";
 
 @Middleware()
 class LocalsMiddleware {
@@ -51,7 +52,7 @@ export function testView(options: PlatformTestOptions) {
     it("should render a view", async () => {
       const response = await request.get("/rest/views/scenario-1").expect(200);
 
-      expect(response.text).to.deep.equal("<p>Hello world with opts and ID local-10909</p>\n");
+      expect(response.text).to.deep.equal(`<p>Hello world with opts and ID local-10909</p>${EOL}`);
     });
   });
 


### PR DESCRIPTION
Fix PlatformExpress - View - Scenario1: GET /rest/views/scenario-1 -
should render a view from #953

<!-- For hacktoberfest PR: Unrelevant modification will be automatically closed and tagged as spam and invalid! -->

## Informations

Type | Breaking change
---|---
Fix | No

****

## Description
Fix Windows tests compatibility
## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
