### PR TITLE
Fix security proto pollution

### DIFF
--- a/packages/common/src/converters/components/MapConverter.ts
+++ b/packages/common/src/converters/components/MapConverter.ts
@@ -1,3 +1,4 @@
+import {objectKeys} from "@tsed/core";
 import {Converter} from "../decorators/converter";
 import {IConverter, IDeserializer, ISerializer} from "../interfaces/index";
 
@@ -19,7 +20,7 @@ export class MapConverter implements IConverter {
   deserialize<T>(data: any, target: any, baseType: T, deserializer: IDeserializer): Map<string, T> {
     const obj = new Map<string, T>();
 
-    Object.keys(data).forEach((key) => {
+    objectKeys(data).forEach((key) => {
       obj.set(key, deserializer(data[key], baseType) as T);
     });
 

--- a/packages/common/src/converters/components/SetConverter.ts
+++ b/packages/common/src/converters/components/SetConverter.ts
@@ -1,3 +1,4 @@
+import {objectKeys} from "@tsed/core";
 import {Converter} from "../decorators/converter";
 import {IConverter, IDeserializer, ISerializer} from "../interfaces/index";
 
@@ -19,7 +20,7 @@ export class SetConverter implements IConverter {
   deserialize<T>(data: any, target: any, baseType: T, deserializer: IDeserializer): Set<T> {
     const obj = new Set<T>();
 
-    Object.keys(data).forEach((key) => {
+    objectKeys(data).forEach((key) => {
       obj.add(deserializer(data[key], baseType) as T);
     });
 

--- a/packages/common/src/converters/services/ConverterService.ts
+++ b/packages/common/src/converters/services/ConverterService.ts
@@ -1,4 +1,4 @@
-import {getClass, isArrayOrArrayClass, isEmpty, isPrimitiveOrPrimitiveClass, Metadata, Type} from "@tsed/core";
+import {getClass, isArrayOrArrayClass, isEmpty, isPrimitiveOrPrimitiveClass, Metadata, objectKeys, Type} from "@tsed/core";
 import {Configuration, Injectable, InjectorService} from "@tsed/di";
 import {IConverterSettings} from "../../config/interfaces/IConverterSettings";
 import {PropertyMetadata} from "../../mvc/models/PropertyMetadata";
@@ -101,7 +101,7 @@ export class ConverterService {
 
     const plainObject: any = {};
     const properties = PropertyMetadata.getProperties(options.type || obj, {withIgnoredProps});
-    const keys = properties.size ? Array.from(properties.keys()) : Object.keys(obj);
+    const keys = properties.size ? Array.from(properties.keys()) : objectKeys(obj);
 
     keys.forEach((propertyKey) => {
       if (typeof obj[propertyKey] !== "function") {
@@ -179,7 +179,7 @@ export class ConverterService {
     const instance = new targetType();
     const properties = PropertyMetadata.getProperties(targetType);
 
-    Object.keys(obj).forEach((propertyName: string) => {
+    objectKeys(obj).forEach((propertyName: string) => {
       const propertyMetadata = ConverterService.getPropertyMetadata(properties, propertyName);
 
       return this.convertProperty(obj, instance, propertyName, propertyMetadata, options);

--- a/packages/common/src/platform/domain/ControllerProvider.spec.ts
+++ b/packages/common/src/platform/domain/ControllerProvider.spec.ts
@@ -1,4 +1,4 @@
-import {getKeys} from "@tsed/core";
+import {getEnumerableKeys} from "@tsed/core";
 import {ProviderScope} from "@tsed/di";
 import {expect} from "chai";
 import {ControllerProvider} from "./ControllerProvider";
@@ -24,7 +24,7 @@ describe("ControllerProvider", () => {
   });
 
   it("should return all keys available for serialisation", () => {
-    expect(getKeys(controllerProvider)).to.deep.equal([
+    expect(getEnumerableKeys(controllerProvider)).to.deep.equal([
       "type",
       "injectable",
       "path",

--- a/packages/core/src/decorators/enumerable.spec.ts
+++ b/packages/core/src/decorators/enumerable.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {Enumerable, getKeys, NotEnumerable} from "../../src";
+import {Enumerable, getEnumerableKeys, NotEnumerable} from "../../src";
 
 class Test1 {
   test: string = "test";
@@ -46,14 +46,14 @@ class Test2 extends Parent1 {
 
 describe("Enumerable", () => {
   it("should have some keys with Test1", () => {
-    expect(getKeys(new Test1())).to.deep.eq(["test", "name"]);
+    expect(getEnumerableKeys(new Test1())).to.deep.eq(["test", "name"]);
     expect(Object.keys(new Test1())).to.deep.eq(["test"]);
     expect(Object.getOwnPropertyNames(new Test1())).to.deep.eq(["test"]);
     expect(Reflect.ownKeys(new Test2())).to.deep.eq(["prop", "test", "_privateTest"]);
   });
 
   it("should have some keys with Test2", () => {
-    expect(getKeys(new Test2())).to.deep.eq(["prop", "test", "first", "privateTest", "name", "parentProp"]);
+    expect(getEnumerableKeys(new Test2())).to.deep.eq(["prop", "test", "first", "privateTest", "name", "parentProp"]);
     expect(Object.keys(new Test2())).to.deep.eq(["prop", "test", "_privateTest"]);
     expect(Object.getOwnPropertyNames(new Test2())).to.deep.eq(["prop", "test", "_privateTest"]);
     expect(Reflect.ownKeys(new Test2())).to.deep.eq(["prop", "test", "_privateTest"]);

--- a/packages/core/src/interfaces/HashOf.ts
+++ b/packages/core/src/interfaces/HashOf.ts
@@ -1,0 +1,1 @@
+export type HashOf<T> = {[key: string]: T};

--- a/packages/core/src/utils/ObjectUtils.ts
+++ b/packages/core/src/utils/ObjectUtils.ts
@@ -363,41 +363,6 @@ export function prototypeOf(target: any) {
 }
 
 /**
- *
- * @param obj
- * @param key
- */
-export function isEnumerable(obj: any, key: string) {
-  const klass = getClass(obj);
-
-  if (klass) {
-    const descriptor = inheritedDescriptorOf(klass, key);
-
-    if (descriptor) {
-      return descriptor.enumerable;
-    }
-  }
-
-  return Object.prototype.propertyIsEnumerable.call(obj, key);
-}
-
-/**
- * Return all enumerable keys of the given object
- * @param obj
- */
-export function getKeys(obj: any) {
-  const keys: string[] = [];
-
-  for (const key in obj) {
-    if (isEnumerable(obj, key)) {
-      keys.push(key);
-    }
-  }
-
-  return keys;
-}
-
-/**
  * Return all methods for a given class.
  * @param target
  */

--- a/packages/core/src/utils/cleanObject.ts
+++ b/packages/core/src/utils/cleanObject.ts
@@ -1,17 +1,19 @@
+import {isProtectedKey} from "./isProtectedKey";
 /**
  * Remove undefined value
  * @param obj
  */
-
 export function cleanObject(obj: any): any {
-  return Object.entries(obj).reduce(
-    (obj, [key, value]) =>
-      value === undefined
-        ? obj
-        : {
-            ...obj,
-            [key]: value
-          },
-    {}
-  );
+  return Object.entries(obj).reduce((obj, [key, value]) => {
+    if (isProtectedKey(key)) {
+      return obj;
+    }
+
+    return value === undefined
+      ? obj
+      : {
+          ...obj,
+          [key]: value
+        };
+  }, {});
 }

--- a/packages/core/src/utils/deepExtends.spec.ts
+++ b/packages/core/src/utils/deepExtends.spec.ts
@@ -38,7 +38,6 @@ describe("deepExtends", () => {
 
         expect(result.withClass).to.be.instanceof(klass);
       });
-
       it("should merge data (3)", () => {
         expect(
           deepExtends(
@@ -52,6 +51,22 @@ describe("deepExtends", () => {
         ).to.deep.eq({
           security: [{"1": "o"}, {"1": "o"}, {"2": "o1"}]
         });
+      });
+      it("should merge data and prevent prototype pollution", () => {
+        const obj = JSON.parse('{"__proto__": {"a": "vulnerable"}, "security":  [{"1": "o"}, {"2": "o1"}]}');
+
+        expect(
+          deepExtends(
+            {
+              security: [{"1": "o"}]
+            },
+            obj
+          )
+        ).to.deep.eq({
+          security: [{"1": "o"}, {"1": "o"}, {"2": "o1"}]
+        });
+
+        expect(({} as any).a).to.eq(undefined);
       });
     });
 

--- a/packages/core/src/utils/deepExtends.ts
+++ b/packages/core/src/utils/deepExtends.ts
@@ -1,13 +1,25 @@
+import {HashOf} from "../interfaces/HashOf";
+import {objectKeys} from "./objectKeys";
 import {classOf, isArrayOrArrayClass, isPrimitive, isPrimitiveOrPrimitiveClass} from "./ObjectUtils";
 
+export type DeepExtendsReducers = HashOf<(collection: any[], value: any) => any>;
+
+function reducer() {
+  return (collection: any[], value: any) => {
+    collection.indexOf(value) === -1 && collection.push(value);
+
+    return collection;
+  };
+}
+
 /**
- *
+ * Deep extends a model with another one.
  * @param out
  * @param obj
- * @param {{[p: string]: (collection: any[], value: any) => any}} reducers
+ * @param reducers
  * @returns {any}
  */
-export function deepExtends(out: any, obj: any, reducers: {[key: string]: (collection: any[], value: any) => any} = {}): any {
+export function deepExtends(out: any, obj: any, reducers: DeepExtendsReducers = {}): any {
   if (obj === undefined || obj === null) {
     return out;
   }
@@ -22,13 +34,8 @@ export function deepExtends(out: any, obj: any, reducers: {[key: string]: (colle
     out = out || (obj ? (classOf(obj) !== Object ? Object.create(obj) : {}) : {});
   }
 
-  const defaultReducer = reducers["default"]
-    ? reducers["default"]
-    : (collection: any[], value: any) => {
-        collection.indexOf(value) === -1 && collection.push(value);
+  const defaultReducer = reducers["default"] ? reducers["default"] : reducer();
 
-        return collection;
-      };
   const set = (key: string | number, value: any) => {
     if (isArrayOrArrayClass(obj)) {
       out.indexOf(value) === -1 && out.push(value);
@@ -37,7 +44,7 @@ export function deepExtends(out: any, obj: any, reducers: {[key: string]: (colle
     }
   };
 
-  Object.keys(obj).forEach((key) => {
+  objectKeys(obj).forEach((key) => {
     let value = obj[key];
 
     if (value === undefined || value === null) {

--- a/packages/core/src/utils/getEnumerableKeys.spec.ts
+++ b/packages/core/src/utils/getEnumerableKeys.spec.ts
@@ -1,0 +1,27 @@
+import {Enumerable, getEnumerableKeys} from "@tsed/core";
+import {expect} from "chai";
+
+describe("getEnumerableKeys", () => {
+  it("should return enumerable keys", () => {
+    class Test {
+      @Enumerable(true)
+      test: string;
+
+      @Enumerable(false)
+      test2: string;
+
+      constructor() {
+        this.test = "test";
+        this.test2 = "test2";
+      }
+    }
+
+    expect(getEnumerableKeys(new Test())).to.deep.eq(["test"]);
+  });
+  it("should return enumerable keys (security test)", () => {
+    const obj = JSON.parse('{"__proto__": {"a": "vulnerable"}, "test": "test"}');
+
+    expect(getEnumerableKeys(obj)).to.deep.eq(["test"]);
+    expect(({} as any).a).to.eq(undefined);
+  });
+});

--- a/packages/core/src/utils/getEnumerableKeys.ts
+++ b/packages/core/src/utils/getEnumerableKeys.ts
@@ -1,0 +1,18 @@
+import {isEnumerable} from "./isEnumerable";
+import {isProtectedKey} from "./isProtectedKey";
+
+/**
+ * Return all enumerable keys of the given object
+ * @param obj
+ */
+export function getEnumerableKeys(obj: any) {
+  const keys: string[] = [];
+
+  for (const key in obj) {
+    if (!isProtectedKey(key) && isEnumerable(obj, key)) {
+      keys.push(key);
+    }
+  }
+
+  return keys;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -9,3 +9,6 @@ export * from "./setValue";
 export * from "./cleanObject";
 export * from "./ObjectUtils";
 export * from "./uniq";
+export * from "./isEnumerable";
+export * from "./getEnumerableKeys";
+export * from "./objectKeys";

--- a/packages/core/src/utils/isEnumerable.ts
+++ b/packages/core/src/utils/isEnumerable.ts
@@ -1,0 +1,20 @@
+import {classOf, inheritedDescriptorOf} from "./ObjectUtils";
+
+/**
+ *
+ * @param obj
+ * @param key
+ */
+export function isEnumerable(obj: any, key: string) {
+  const klass = classOf(obj);
+
+  if (klass) {
+    const descriptor = inheritedDescriptorOf(klass, key);
+
+    if (descriptor) {
+      return descriptor.enumerable;
+    }
+  }
+
+  return Object.prototype.propertyIsEnumerable.call(obj, key);
+}

--- a/packages/core/src/utils/isProtectedKey.spec.ts
+++ b/packages/core/src/utils/isProtectedKey.spec.ts
@@ -1,0 +1,15 @@
+import {expect} from "chai";
+import {isProtectedKey} from "./isProtectedKey";
+
+describe("isProtectedKey", () => {
+  it("should return true", () => {
+    expect(isProtectedKey("__proto__")).to.eq(true);
+    expect(isProtectedKey("prototype")).to.eq(true);
+    expect(isProtectedKey("constructor")).to.eq(true);
+  });
+  it("should return false", () => {
+    expect(isProtectedKey("test")).to.eq(false);
+    expect(isProtectedKey("pro")).to.eq(false);
+    expect(isProtectedKey("const")).to.eq(false);
+  });
+});

--- a/packages/core/src/utils/isProtectedKey.ts
+++ b/packages/core/src/utils/isProtectedKey.ts
@@ -1,0 +1,7 @@
+/**
+ * Prevent prototype pollution vulnerability
+ * @param key
+ */
+export function isProtectedKey(key: string) {
+  return ["__proto__", "constructor", "prototype"].includes(key);
+}

--- a/packages/core/src/utils/objectKeys.spec.ts
+++ b/packages/core/src/utils/objectKeys.spec.ts
@@ -1,0 +1,11 @@
+import {expect} from "chai";
+import {objectKeys} from "./objectKeys";
+
+describe("objectKeys", () => {
+  it("should return only authorized keys", () => {
+    const obj = JSON.parse('{"__proto__": {"a": "vulnerable"}, "test": "test"}');
+
+    expect(objectKeys(obj)).to.deep.eq(["test"]);
+    expect(({} as any).a).to.eq(undefined);
+  });
+});

--- a/packages/core/src/utils/objectKeys.ts
+++ b/packages/core/src/utils/objectKeys.ts
@@ -1,0 +1,5 @@
+import {isProtectedKey} from "./isProtectedKey";
+
+export function objectKeys(obj: any): string[] {
+  return Object.keys(obj).filter((key) => !isProtectedKey(key));
+}

--- a/packages/core/src/utils/setValue.spec.ts
+++ b/packages/core/src/utils/setValue.spec.ts
@@ -50,4 +50,13 @@ describe("setValue()", () => {
       expect(map.test.t1).to.eq("value2");
     });
   });
+
+  describe("when object with dep (without defined value)", () => {
+    it("should set value", () => {
+      const obj = {};
+      setValue("__proto__", "vulnerable", obj);
+      expect(obj).to.deep.eq({});
+      expect(({} as any).a).to.eq(undefined);
+    });
+  });
 });

--- a/packages/core/src/utils/setValue.ts
+++ b/packages/core/src/utils/setValue.ts
@@ -1,7 +1,13 @@
+import {isProtectedKey} from "./isProtectedKey";
+
 export function setValue(expression: string, value: any, scope: any, separator = ".") {
   const keys: string[] = expression.split(separator);
 
   const setValue = (key: string, add: boolean) => {
+    if (isProtectedKey(key)) {
+      return false;
+    }
+
     if (add) {
       if (typeof scope.set === "function") {
         scope.set(key, value);

--- a/packages/di/src/class/Provider.spec.ts
+++ b/packages/di/src/class/Provider.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {getKeys} from "../../../core/src/utils";
+import {getEnumerableKeys} from "../../../core/src/utils";
 import {Provider} from "../../src/class/Provider";
 import {ProviderScope} from "../../src/interfaces";
 
@@ -17,7 +17,7 @@ describe("Provider", () => {
       expect(provider.provide).to.eq(T1);
       expect(provider.useClass).to.eq(T1);
       expect(!!provider.store).to.eq(true);
-      expect(getKeys(provider)).to.deep.eq([
+      expect(getEnumerableKeys(provider)).to.deep.eq([
         "type",
         "injectable",
         "customProp",

--- a/packages/di/src/class/Provider.ts
+++ b/packages/di/src/class/Provider.ts
@@ -1,4 +1,4 @@
-import {classOf, Enumerable, getKeys, isClass, nameOf, NotEnumerable, Store, Type} from "@tsed/core";
+import {classOf, Enumerable, getEnumerableKeys, isClass, nameOf, NotEnumerable, Store, Type} from "@tsed/core";
 import {ProviderScope} from "../interfaces";
 import {IProvider} from "../interfaces/IProvider";
 import {ProviderType} from "../interfaces/ProviderType";
@@ -140,7 +140,7 @@ export class Provider<T = any> implements IProvider<T> {
   clone(): Provider<any> {
     const provider = new (classOf(this))(this.token);
 
-    getKeys(this).forEach((key) => {
+    getEnumerableKeys(this).forEach((key) => {
       if (this[key] !== undefined) {
         provider[key] = this[key];
       }

--- a/packages/json-mapper/src/components/MapMapper.ts
+++ b/packages/json-mapper/src/components/MapMapper.ts
@@ -1,3 +1,4 @@
+import {objectKeys} from "@tsed/core";
 import {JsonMapper} from "../decorators/jsonMapper";
 import {JsonMapperCtx, JsonMapperMethods} from "../interfaces/JsonMapperMethods";
 
@@ -12,7 +13,7 @@ export class MapMapper implements JsonMapperMethods {
   deserialize<T = any, C = Map<string, T>>(data: {[key: string]: any}, ctx: JsonMapperCtx<T, C>): Map<string, T> {
     const obj = new Map<string, T>();
 
-    Object.keys(data).forEach((key) => {
+    objectKeys(data).forEach((key) => {
       obj.set(key, ctx.next(data[key]) as T);
     });
 

--- a/packages/json-mapper/src/components/SetMapper.ts
+++ b/packages/json-mapper/src/components/SetMapper.ts
@@ -1,3 +1,4 @@
+import {objectKeys} from "@tsed/core";
 import {JsonMapper} from "../decorators/jsonMapper";
 import {JsonMapperCtx, JsonMapperMethods} from "../interfaces/JsonMapperMethods";
 
@@ -12,7 +13,7 @@ export class SetMapper implements JsonMapperMethods {
   deserialize<T>(data: any, ctx: JsonMapperCtx): Set<T> {
     const obj = new Set<T>();
 
-    Object.keys(data).forEach((key) => {
+    objectKeys(data).forEach((key) => {
       obj.add(ctx.next(data[key]));
     });
 

--- a/packages/json-mapper/src/utils/deserialize.ts
+++ b/packages/json-mapper/src/utils/deserialize.ts
@@ -1,4 +1,4 @@
-import {isArray, isEmpty, isNil, MetadataTypes, nameOf, Type} from "@tsed/core";
+import {isArray, isEmpty, isNil, MetadataTypes, nameOf, objectKeys, Type} from "@tsed/core";
 import {getPropertiesStores, JsonEntityStore, JsonHookContext, JsonSchema} from "@tsed/schema";
 import "../components";
 import {JsonMapperContext} from "../domain/JsonMapperContext";
@@ -77,7 +77,7 @@ export function plainObjectToClass<T = any>(src: any, options: JsonDeserializerO
   const {type, store = JsonEntityStore.from(type), ...next} = options;
   const propertiesMap = getPropertiesStores(store);
 
-  let keys = Object.keys(src);
+  let keys = objectKeys(src);
   const additionalProperties = propertiesMap.size ? !!store.schema.get("additionalProperties") || options.additionalProperties : true;
   const out: any = new type(src);
 

--- a/packages/mongoose/src/utils/cleanProps.ts
+++ b/packages/mongoose/src/utils/cleanProps.ts
@@ -1,8 +1,0 @@
-export const cleanProps = (src: any) =>
-  Object.keys(src).reduce((obj: any, k: any) => {
-    if (src[k] !== undefined) {
-      obj[k] = src[k];
-    }
-
-    return obj;
-  }, {});

--- a/packages/mongoose/src/utils/createSchema.ts
+++ b/packages/mongoose/src/utils/createSchema.ts
@@ -1,10 +1,9 @@
 import {ConverterService, IConverterOptions, JsonSchema, PropertyMetadata} from "@tsed/common";
-import {getClass, Store, Type} from "@tsed/core";
+import {cleanObject, getClass, Store, Type} from "@tsed/core";
 import * as mongoose from "mongoose";
 import {SchemaDefinition, SchemaTypeOpts} from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";
 import {MongooseSchemaOptions} from "../interfaces";
-import {cleanProps} from "./cleanProps";
 import {schemaOptions} from "./schemaOptions";
 
 const MONGOOSE_RESERVED_KEYS = ["_id"];
@@ -132,7 +131,7 @@ export function createSchemaTypeOptions(propertyMetadata: PropertyMetadata): Sch
     schemaTypeOptions = {...schemaTypeOptions, type: getSchema(propertyMetadata.type)};
   }
 
-  schemaTypeOptions = cleanProps({...schemaTypeOptions, ...rawMongooseSchema});
+  schemaTypeOptions = cleanObject({...schemaTypeOptions, ...rawMongooseSchema});
 
   if (propertyMetadata.isCollection) {
     if (propertyMetadata.isArray) {


### PR DESCRIPTION
<!-- For hacktoberfest PR: Unrelevant modification will be automatically closed and tagged as spam and invalid! -->

## Informations

Type | Breaking change
---|---
Fix | No

****

## Description
Prevent prototype pollution when using deepExtends function, converterService or @tsed/json-mapper functions.

- [x] @tsed/core
- [x] @tsed/common
- [x] @tsed/json-mapper

