### PR TITLE
fix(schema): Fix Required metadata with schema inheritance

### DIFF
--- a/packages/schema/src/utils/serializeJsonSchema.ts
+++ b/packages/schema/src/utils/serializeJsonSchema.ts
@@ -1,4 +1,4 @@
-import {classOf, deepExtends, isArray, isObject} from "@tsed/core";
+import {classOf, deepExtends, isArray, isObject, uniq} from "@tsed/core";
 import {mapAliasedProperties} from "../domain/JsonAliasMap";
 import {JsonSchema} from "../domain/JsonSchema";
 import {SpecTypes} from "../domain/SpecTypes";
@@ -239,7 +239,7 @@ export function serializeJsonSchema(schema: JsonSchema, options: JsonSchemaOptio
   obj = serializeGenerics(obj, {...options, root: false, schemas} as any);
 
   if (schema.$required.size) {
-    obj.required = getRequired(schema, useAlias);
+    obj.required = uniq([...(obj.required || []), ...getRequired(schema, useAlias)]);
   }
 
   return obj;


### PR DESCRIPTION
Required field is correctly generated when there is inheritance with a mixin

Closes: #1030


```typescript
it("should keep required meta from inherited class", () => {
    // WHEN
    const AutoUUID = <T extends Type<any>>(Base: T) => {
      class AutoUUIDMixin extends Base {
        @Property() //showing up in swagger as a property
        @Format("uuid") //showing up as a uuid in swagger
        @Required(true)
        id: string;
      }

      return AutoUUIDMixin;
    };

    const WithDates = <T extends Type<any>>(Base: T) => {
      class WithDates extends Base {
        @Property() //showing up in swagger as a property
        @Format("datetime") //showing up as a uuid in swagger
        @Required(true)
        created_at: string;

        @Property() //showing up in swagger as a property
        @Format("datetime") //showing up as a uuid in swagger
        @Required(true)
        updated_at: string;
      }

      return WithDates;
    };

    class Model {
      @Required()
      name: string;
    }

    const DefaultMixins = <T extends Type<any>>(Base: T) => AutoUUID(WithDates(Base));

    class EmailTemplate extends DefaultMixins(Model) {
      @Required()
      engine: string;
    }

    // THEN
    expect(ancestorsOf(EmailTemplate).map(nameOf)).to.deep.equal(["Model", "WithDates", "AutoUUIDMixin", "EmailTemplate"]);
    expect(getJsonSchema(EmailTemplate)).to.deep.equal({
      properties: {
        created_at: {
          format: "datetime",
          minLength: 1,
          type: "string"
        },
        engine: {
          minLength: 1,
          type: "string"
        },
        id: {
          format: "uuid",
          minLength: 1,
          type: "string"
        },
        name: {
          minLength: 1,
          type: "string"
        },
        updated_at: {
          format: "datetime",
          minLength: 1,
          type: "string"
        }
      },
      required: ["name", "created_at", "updated_at", "id", "engine"],
      type: "object"
    });
  });
```