### PR TITLE
fix(#1057): Value returned by an endpoint without @Returns is now correctly serialized

### DIFF
--- a/packages/json-mapper/src/utils/serialize.spec.ts
+++ b/packages/json-mapper/src/utils/serialize.spec.ts
@@ -263,7 +263,7 @@ describe("serialize()", () => {
         }
       });
     });
-    it("should discover property dynamicly when any schema decorators are used", () => {
+    it("should discover property dynamically when any schema decorators are used", () => {
       function log(): PropertyDecorator {
         return () => {};
       }

--- a/packages/json-mapper/src/utils/serialize.ts
+++ b/packages/json-mapper/src/utils/serialize.ts
@@ -94,6 +94,9 @@ function toObject(obj: any, options: JsonSerializerOptions): any {
 export function serialize(obj: any, {type, collectionType, ...options}: JsonSerializerOptions = {}): any {
   const types = options.types ? options.types : getJsonMapperTypes();
 
+  // prevent Object metadata assignation. TypeScript set Object by default on endpoint.type
+  type = type === Object ? undefined : type;
+
   if (isEmpty(obj)) {
     return obj;
   }

--- a/packages/json-mapper/test/integration/ignore.integration.spec.ts
+++ b/packages/json-mapper/test/integration/ignore.integration.spec.ts
@@ -1,0 +1,36 @@
+import {Ignore, Property} from "@tsed/schema";
+import {expect} from "chai";
+import {serialize} from "../../src";
+
+describe("Mapping @Ignore", () => {
+  it("should serialize model", () => {
+    class Base {
+      @Ignore()
+      ignoreMeBase: string;
+
+      @Property()
+      fooBase: string;
+    }
+
+    class MyModel extends Base {
+      @Property()
+      foo: string;
+
+      @Ignore()
+      ignoreMe: string;
+    }
+
+    const model = new MyModel();
+    model.foo = "foo";
+    model.ignoreMe = "ignoreMe";
+    model.fooBase = "fooBase";
+    model.ignoreMeBase = "ignoreMeBase";
+
+    const result = serialize(model, {type: Object});
+
+    expect(result).to.deep.eq({
+      foo: "foo",
+      fooBase: "fooBase"
+    });
+  });
+});


### PR DESCRIPTION
Closes: #1057
