### PR TITLE
docs: fix provider type in injectable service snippet

### DIFF
--- a/docs/docs/snippets/providers/getting-started-injectable.ts
+++ b/docs/docs/snippets/providers/getting-started-injectable.ts
@@ -2,7 +2,7 @@ import {Injectable, ProviderScope, ProviderType} from "@tsed/common";
 import {Calendar} from "../models/Calendar";
 
 @Injectable({
-  type: ProviderType.CONTROLLER,
+  type: ProviderType.SERVICE,
   scope: ProviderScope.SINGLETON
 })
 export class CalendarsService {


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Doc | No

****

## Description
Correct the provider type to `ProviderType.SERVICE` in the sample snippet of how to use `@Injectable` for services. The previous version had `ProviderType.CONTROLLER` and would throw an `INJECTION_ERROR` with `TypeError: provider.hasParent is not a function`.
