### PR TITLE
feat(schema): Add @AnyOf, @AllOf, @OneOf and @For decorators

### DIFF
--- a/packages/schema/src/decorators/common/allOf.spec.ts
+++ b/packages/schema/src/decorators/common/allOf.spec.ts
@@ -1,0 +1,33 @@
+import {expect} from "chai";
+import {JsonEntityStore} from "../../domain/JsonEntityStore";
+import {number, string} from "../../utils/from";
+import {AllOf} from "./allOf";
+
+describe("@AllOf", () => {
+  it("should declare return schema", () => {
+    // WHEN
+    class Model {
+      @AllOf(string(), number())
+      num: string;
+    }
+
+    // THEN
+    const classSchema = JsonEntityStore.from(Model);
+
+    expect(classSchema.schema.toJSON()).to.deep.equal({
+      properties: {
+        num: {
+          allOf: [
+            {
+              type: "string"
+            },
+            {
+              type: "number"
+            }
+          ]
+        }
+      },
+      type: "object"
+    });
+  });
+});

--- a/packages/schema/src/decorators/common/allOf.ts
+++ b/packages/schema/src/decorators/common/allOf.ts
@@ -1,0 +1,20 @@
+import {JsonSchema} from "../../domain/JsonSchema";
+import {JSONSchema6} from "json-schema";
+import {Schema} from "./schema";
+
+/**
+ * See https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.26
+ *
+ * @decorator
+ * @validation
+ * @swagger
+ * @schema
+ * @classDecorator
+ * @input
+ * @param allOf
+ */
+export function AllOf(...allOf: (Partial<JSONSchema6> | JsonSchema)[]) {
+  return Schema({
+    allOf: allOf as any[]
+  });
+}

--- a/packages/schema/src/decorators/common/anyOf.spec.ts
+++ b/packages/schema/src/decorators/common/anyOf.spec.ts
@@ -1,0 +1,33 @@
+import {expect} from "chai";
+import {JsonEntityStore} from "../../domain/JsonEntityStore";
+import {number, string} from "../../utils/from";
+import {AnyOf} from "./anyOf";
+
+describe("@AnyOf", () => {
+  it("should declare return schema", () => {
+    // WHEN
+    class Model {
+      @AnyOf(string(), number())
+      num: string;
+    }
+
+    // THEN
+    const classSchema = JsonEntityStore.from(Model);
+
+    expect(classSchema.schema.toJSON()).to.deep.equal({
+      properties: {
+        num: {
+          anyOf: [
+            {
+              type: "string"
+            },
+            {
+              type: "number"
+            }
+          ]
+        }
+      },
+      type: "object"
+    });
+  });
+});

--- a/packages/schema/src/decorators/common/anyOf.ts
+++ b/packages/schema/src/decorators/common/anyOf.ts
@@ -1,0 +1,24 @@
+import {JsonSchema} from "../../domain/JsonSchema";
+import {JSONSchema6} from "json-schema";
+import {Schema} from "./schema";
+
+/**
+ * See https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.27
+ *
+ * ::: warning
+ * AnyOf isn't supported by OS2
+ * :::
+ *
+ * @decorator
+ * @validation
+ * @swagger
+ * @schema
+ * @classDecorator
+ * @input
+ * @param anyOf
+ */
+export function AnyOf(...anyOf: (Partial<JSONSchema6> | JsonSchema)[]) {
+  return Schema({
+    anyOf: anyOf as any[]
+  });
+}

--- a/packages/schema/src/decorators/common/oneOf.spec.ts
+++ b/packages/schema/src/decorators/common/oneOf.spec.ts
@@ -1,0 +1,33 @@
+import {OneOf} from "@tsed/schema";
+import {expect} from "chai";
+import {JsonEntityStore} from "../../domain/JsonEntityStore";
+import {number, string} from "../../utils/from";
+
+describe("@OneOf", () => {
+  it("should declare return schema", () => {
+    // WHEN
+    class Model {
+      @OneOf(string(), number())
+      num: string;
+    }
+
+    // THEN
+    const classSchema = JsonEntityStore.from(Model);
+
+    expect(classSchema.schema.toJSON()).to.deep.equal({
+      properties: {
+        num: {
+          oneOf: [
+            {
+              type: "string"
+            },
+            {
+              type: "number"
+            }
+          ]
+        }
+      },
+      type: "object"
+    });
+  });
+});

--- a/packages/schema/src/decorators/common/oneOf.ts
+++ b/packages/schema/src/decorators/common/oneOf.ts
@@ -1,0 +1,24 @@
+import {JsonSchema} from "../../domain/JsonSchema";
+import {JSONSchema6} from "json-schema";
+import {Schema} from "./schema";
+
+/**
+ * See https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.28
+ *
+ * ::: warning
+ * OneOf isn't supported by OS2
+ * :::
+ *
+ * @decorator
+ * @validation
+ * @swagger
+ * @schema
+ * @classDecorator
+ * @input
+ * @param oneOf
+ */
+export function OneOf(...oneOf: (Partial<JSONSchema6> | JsonSchema)[]) {
+  return Schema({
+    oneOf: oneOf as any[]
+  });
+}

--- a/packages/schema/src/decorators/common/schema.ts
+++ b/packages/schema/src/decorators/common/schema.ts
@@ -1,4 +1,6 @@
 import {JSONSchema6} from "json-schema";
+import {JsonSchema} from "../../domain/JsonSchema";
+import {SpecTypes} from "../../domain/SpecTypes";
 import {JsonEntityFn} from "./jsonEntityFn";
 
 /**
@@ -39,10 +41,27 @@ import {JsonEntityFn} from "./jsonEntityFn";
  * @classDecorator
  * @input
  */
-export function Schema(partialSchema: Partial<JSONSchema6>) {
+export function Schema(partialSchema: Partial<JSONSchema6 | JsonSchema>) {
   return JsonEntityFn((entity) => {
     Object.entries(partialSchema).forEach(([key, value]) => {
       entity.schema.set(key, value);
     });
+  });
+}
+
+/**
+ * Apply specific schema depending on the spec version
+ * @param specType
+ * @param schema
+ * @decorator
+ * @validation
+ * @swagger
+ * @schema
+ * @classDecorator
+ * @input
+ */
+export function For(specType: SpecTypes, schema: any) {
+  return JsonEntityFn((entity) => {
+    entity.schema.set(specType, schema);
   });
 }

--- a/packages/schema/src/decorators/index.ts
+++ b/packages/schema/src/decorators/index.ts
@@ -52,5 +52,8 @@ export * from "./common/required";
 export * from "./common/property";
 export * from "./common/title";
 export * from "./common/schema";
+export * from "./common/oneOf";
+export * from "./common/allOf";
+export * from "./common/anyOf";
 export * from "./common/jsonEntityFn";
 export * from "./config/jsonEntityComponent";

--- a/packages/schema/src/domain/JsonSchema.ts
+++ b/packages/schema/src/domain/JsonSchema.ts
@@ -9,6 +9,7 @@ import {serializeJsonSchema} from "../utils/serializeJsonSchema";
 import {toJsonRegex} from "../utils/toJsonRegex";
 import {AliasMap, AliasType} from "./JsonAliasMap";
 import {JsonFormatTypes} from "./JsonFormatTypes";
+import {SpecTypes} from "./SpecTypes";
 
 export interface JsonSchemaObject extends JSONSchema6 {
   type: (any | JSONSchema6TypeName) | (any | JSONSchema6TypeName)[];
@@ -54,6 +55,7 @@ export class JsonSchema extends Map<string, any> implements NestedGenerics {
   protected _isGeneric: boolean = false;
   protected _isCollection: boolean = false;
   protected _ref: boolean = false;
+  protected _specs: Map<SpecTypes, any> = new Map();
 
   constructor(obj: JsonSchema | Partial<JsonSchemaObject> = {}) {
     super();
@@ -785,8 +787,7 @@ export class JsonSchema extends Map<string, any> implements NestedGenerics {
 
   set(key: string, value: any): this {
     if (key in this) {
-      // @ts-ignore
-      this[key](value);
+      isFunction((this as any)[key]) && (this as any)[key](value);
     } else {
       super.set(key, value);
     }

--- a/packages/schema/src/utils/from.spec.ts
+++ b/packages/schema/src/utils/from.spec.ts
@@ -1,4 +1,23 @@
-import {any, array, boolean, date, datetime, email, from, integer, map, number, object, set, string, time, uri, url} from "@tsed/schema";
+import {
+  allOf,
+  any,
+  anyOf,
+  array,
+  boolean,
+  date,
+  datetime,
+  email,
+  from,
+  integer,
+  map,
+  number,
+  object,
+  set,
+  string,
+  time,
+  uri,
+  url
+} from "@tsed/schema";
 import {expect} from "chai";
 
 describe("from", () => {
@@ -50,6 +69,14 @@ describe("from", () => {
     expect(array().toJSON()).to.deep.eq({type: "array"});
     expect(any().toJSON()).to.deep.eq({
       type: ["integer", "number", "string", "boolean", "array", "object", "null"]
+    });
+
+    expect(anyOf(string(), number()).toJSON()).to.deep.eq({
+      anyOf: [{type: "string"}, {type: "number"}]
+    });
+
+    expect(allOf(string(), number()).toJSON()).to.deep.eq({
+      allOf: [{type: "string"}, {type: "number"}]
     });
   });
   it("should create ref when use a label", () => {

--- a/packages/schema/src/utils/from.ts
+++ b/packages/schema/src/utils/from.ts
@@ -79,3 +79,15 @@ export function object(properties: {[key: string]: JsonSchema} = {}) {
 export function any(...types: any[]) {
   return from().any(...types);
 }
+
+export function anyOf(...anyOf: any[]) {
+  return from().anyOf(anyOf);
+}
+
+export function oneOf(...oneOf: any[]) {
+  return from().oneOf(oneOf);
+}
+
+export function allOf(...allOf: any[]) {
+  return from().allOf(allOf);
+}

--- a/packages/schema/src/utils/serializeJsonSchema.ts
+++ b/packages/schema/src/utils/serializeJsonSchema.ts
@@ -12,7 +12,7 @@ import {getRequiredProperties} from "./getRequiredProperties";
 /**
  * @ignore
  */
-const IGNORES = ["name", "$required", "$hooks", "_nestedGenerics"];
+const IGNORES = ["name", "$required", "$hooks", "_nestedGenerics", SpecTypes.OPENAPI, SpecTypes.SWAGGER, SpecTypes.JSON];
 /**
  * @ignore
  */
@@ -276,6 +276,17 @@ export function serializeJsonSchema(schema: JsonSchema, options: JsonSchemaOptio
 
   obj = serializeGenerics(obj, {...options, root: false, schemas} as any);
   obj = getRequiredProperties(obj, schema, useAlias);
+
+  if (schema.has(options.specType as string)) {
+    obj = {
+      ...obj,
+      ...schema.get(options.specType as string).toJSON(options)
+    };
+  }
+
+  if ((obj.oneOf || obj.allOf || obj.anyOf) && !(obj.items || obj.properties)) {
+    delete obj.type;
+  }
 
   return obj;
 }


### PR DESCRIPTION

## Information

Type | Breaking change
---|---
Feature | No

****
## Usage example

Update functional JsonSchema declaration utils:

```typescript
import {
  CollectionOf,
  Default,
  Description,
  Integer,
  MaxItems,
  Min,
  MinLength,
  Property,
  Required,
  For,
  SpecTypes,
  oneOf,
  string,
  array
} from "@tsed/schema";
import {OnDeserialize} from "@tsed/json-mapper";
import {isArray} from "@tsed/core";

class Pageable {
  @Integer()
  @Min(0)
  @Default(0)
  @Description("Page number.")
  page: number = 0;

  @Integer()
  @Min(1)
  @Default(20)
  @Description("Number of objects per page.")
  size: number = 20;

  @For(SpecTypes.JSON, oneOf(string(), array().items(string()).maxItems(2)))
  @For(SpecTypes.OPENAPI, array().items(string()).maxItems(2))
  @For(SpecTypes.SWAGGER, array().items(string()).maxItems(2))
  @OnDeserialize((value: string | string[]) => isString(value) ? value.split(",") : value)
  @Description("Sorting criteria: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.")
  sort: string | string[];

  constructor(options: Partial<Pageable>) {
    options.page && (this.page = options.page);
    options.size && (this.size = options.size);
    options.sort && (this.sort = options.sort);
  }

  get offset() {
    return this.page ? this.page * this.limit : 0;
  }

  get limit() {
    return this.size;
  }
}
```


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [ ] Documentation
