### PR TITLE
fixed ResolverService decorator using wrong options type

### DIFF
--- a/packages/graphql/src/decorators/resolverService.ts
+++ b/packages/graphql/src/decorators/resolverService.ts
@@ -1,11 +1,11 @@
 import {ClassType, Resolver} from "type-graphql";
-import {ClassTypeResolver, ResolverClassOptions} from "type-graphql/dist/decorators/types";
+import {ClassTypeResolver, AbstractClassOptions} from "type-graphql/dist/decorators/types";
 import {registerResolverService} from "../registries/ResolverServiceRegistry";
 
 export function ResolverService(): ClassDecorator;
-export function ResolverService(options: ResolverClassOptions): ClassDecorator;
-export function ResolverService(typeFunc: ClassTypeResolver, options?: ResolverClassOptions): ClassDecorator;
-export function ResolverService(objectType: ClassType, options?: ResolverClassOptions): ClassDecorator;
+export function ResolverService(options: AbstractClassOptions): ClassDecorator;
+export function ResolverService(typeFunc: ClassTypeResolver, options?: AbstractClassOptions): ClassDecorator;
+export function ResolverService(objectType: ClassType, options?: AbstractClassOptions): ClassDecorator;
 export function ResolverService(...args: any[]): ClassDecorator {
   return <TFunction extends Function>(target: TFunction): void => {
     Resolver.apply(this, args)(target);


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix| No

****

## Description
This PR changes the type of the `ResolverService `options from `ResolverClassOptions` to `AbstractClassOptions`, since in the newer versions of `type-graphql` there is no `ResolverClassOptions` exported anymore and this causes errors when fresh installing `type-graphql` and trying to build the project.
