### PR TITLE
Fix 1125 accept middlewares

### DIFF
--- a/docs/docs/custom-endpoint-decorators.md
+++ b/docs/docs/custom-endpoint-decorators.md
@@ -18,23 +18,23 @@ Many other decorators are implemented and can be taken as an example to build yo
 
 ## Build your own decorator
 
-One of the use cases already implemented by Ts.ED is the @@AcceptMimesMiddleware@@:
+One of the use cases already implemented by Ts.ED is the @@PlatformAcceptMimesMiddleware@@:
 
-<<< @/packages/common/src/mvc/middlewares/AcceptMimesMiddleware.ts
+<<< @/packages/common/src/platform/middlewares/PlatformAcceptMimesMiddleware.ts
 
 You can see in this example the usage of `endpoint.get` from @@EndpointInfo@@. This method contains all options
-which can be passed to the decorator associated to AcceptMimesMiddleware.
+which can be passed to the decorator associated to PlatformAcceptMimesMiddleware.
 
 <<< @/docs/docs/snippets/middlewares/accept-mime-usage.ts
 
 ::: tip
 This example uses @@AcceptMime@@ decorator with one option, the `application/json`. 
-This option will be set to `endpoint.get` seen before with AcceptMimesMiddleware example and can be retrieved by using 
-`endpoint.get(AcceptMimesMiddleware)`.
+This option will be set to `endpoint.get` seen before with PlatformAcceptMimesMiddleware example and can be retrieved by using 
+`endpoint.get(PlatformAcceptMimesMiddleware)`.
 :::
 
 Ts.ED provides API to create your own decorator like @@AcceptMime@@ which registers the options and at least one middleware
-with theses decorators and utils:
+with these decorators and utils:
 
 - @@Use@@, @@UseBeforeEach@@, @@UseBefore@@, or @@UseAfter@@ for middleware registration,
 - @@applyDecorator@@ if you want to combine different decorators,

--- a/docs/docs/middlewares.md
+++ b/docs/docs/middlewares.md
@@ -31,8 +31,7 @@ can access to the last executed endpoint information.
 
 ## Global middleware 
 
-Global middlewares are generally used to handle requests before or after controllers. For example the GlobalAcceptMimesMiddleware
-is used to check the mime type set in the request headers and throw an error when the mime don't match with server configuration.
+Global middlewares are generally used to handle requests before or after controllers.
 
 <<< @/docs/docs/snippets/middlewares/global-middleware.ts
 

--- a/packages/common/src/mvc/decorators/method/acceptMime.spec.ts
+++ b/packages/common/src/mvc/decorators/method/acceptMime.spec.ts
@@ -1,5 +1,4 @@
-import {AcceptMime, AcceptMimesMiddleware, Get} from "@tsed/common";
-import {Store} from "@tsed/core";
+import {AcceptMime, EndpointMetadata, Get} from "@tsed/common";
 import {getSpec} from "@tsed/schema";
 import {expect} from "chai";
 
@@ -11,8 +10,9 @@ describe("AcceptMime", () => {
       test() {}
     }
 
-    const store = Store.fromMethod(Test, "test");
-    expect(store.get(AcceptMimesMiddleware)).to.deep.eq(["application/json"]);
+    const endpoint = EndpointMetadata.get(Test, "test");
+    expect(endpoint.acceptMimes).to.deep.eq(["application/json"]);
+
     const spec = getSpec(Test);
 
     expect(spec).to.deep.eq({

--- a/packages/common/src/mvc/decorators/method/acceptMime.ts
+++ b/packages/common/src/mvc/decorators/method/acceptMime.ts
@@ -1,7 +1,6 @@
-import {StoreSet, useDecorators} from "@tsed/core";
+import {useDecorators} from "@tsed/core";
 import {Produces} from "@tsed/schema";
-import {AcceptMimesMiddleware} from "../../middlewares/AcceptMimesMiddleware";
-import {UseBefore} from "./useBefore";
+import {EndpointFn} from "./endpointFn";
 
 /**
  * Set a mime list which are acceptable and checks if the specified content types are acceptable, based on the request’s Accept HTTP header field.
@@ -22,5 +21,10 @@ import {UseBefore} from "./useBefore";
  * @response
  */
 export function AcceptMime(...mimes: string[]): Function {
-  return useDecorators(Produces(...mimes), StoreSet(AcceptMimesMiddleware, mimes), UseBefore(AcceptMimesMiddleware));
+  return useDecorators(
+    Produces(...mimes),
+    EndpointFn((endpoint) => {
+      endpoint.acceptMimes = mimes;
+    })
+  );
 }

--- a/packages/common/src/mvc/middlewares/AcceptMimesMiddleware.spec.ts
+++ b/packages/common/src/mvc/middlewares/AcceptMimesMiddleware.spec.ts
@@ -1,60 +1,12 @@
-import {AcceptMime, AcceptMimesMiddleware, EndpointMetadata, Get, PlatformRequest, PlatformTest} from "@tsed/common";
-import {catchError} from "@tsed/core";
-import {expect} from "chai";
-import * as Sinon from "sinon";
-import {FakeRequest} from "../../../../../test/helper";
-
-const sandbox = Sinon.createSandbox();
+import {AcceptMimesMiddleware, PlatformTest} from "@tsed/common";
 
 describe("AcceptMimesMiddleware", () => {
   beforeEach(() => PlatformTest.create());
   afterEach(() => PlatformTest.reset());
   it("should accept type", async () => {
-    class Test {
-      @Get("/")
-      @AcceptMime("application/json")
-      get() {}
-    }
-
-    const endpoint = EndpointMetadata.get(Test, "get");
-    const request: any = new FakeRequest({
-      sandbox,
-      headers: {
-        accept: "application/json"
-      }
-    });
-    const ctx = PlatformTest.createRequestContext({
-      request: new PlatformRequest(request),
-      endpoint
-    });
+    const ctx = PlatformTest.createRequestContext();
 
     const middleware = await PlatformTest.invoke<AcceptMimesMiddleware>(AcceptMimesMiddleware);
     middleware.use(ctx);
-
-    expect(request.accepts).to.have.been.calledWithExactly(["application/json"]);
-  });
-  it("should refuse type", async () => {
-    class Test {
-      @Get("/")
-      @AcceptMime("application/json")
-      get() {}
-    }
-
-    const endpoint = EndpointMetadata.get(Test, "get");
-    const request: any = new FakeRequest({
-      sandbox,
-      headers: {
-        accept: "application/xml"
-      }
-    });
-    const ctx = PlatformTest.createRequestContext({
-      request: new PlatformRequest(request),
-      endpoint
-    });
-    const middleware = await PlatformTest.invoke<AcceptMimesMiddleware>(AcceptMimesMiddleware);
-
-    const error: any = catchError(() => middleware.use(ctx));
-
-    expect(error.message).to.equal("You must accept content-type application/json");
   });
 });

--- a/packages/common/src/mvc/middlewares/AcceptMimesMiddleware.ts
+++ b/packages/common/src/mvc/middlewares/AcceptMimesMiddleware.ts
@@ -1,19 +1,15 @@
-import {NotAcceptable} from "@tsed/exceptions";
 import {Middleware} from "../../mvc/decorators";
 import {IMiddleware} from "../../mvc/interfaces";
 import {Context} from "../../platform/decorators/context";
 
 /**
  * @middleware
+ * @deprecated Since 2020-11-30. Use PlatformAcceptMimesMiddleware.
+ * @ignore
  */
 @Middleware()
 export class AcceptMimesMiddleware implements IMiddleware {
   public use(@Context() ctx: Context): void {
-    const {endpoint, request} = ctx;
-    const mimes = endpoint.get(AcceptMimesMiddleware) || [];
-
-    if (!request.accepts(mimes)) {
-      throw new NotAcceptable(mimes.join(", "));
-    }
+    return;
   }
 }

--- a/packages/common/src/mvc/models/EndpointMetadata.ts
+++ b/packages/common/src/mvc/models/EndpointMetadata.ts
@@ -1,5 +1,5 @@
 import {classOf, DecoratorTypes, deepExtends, descriptorOf, Enumerable, isFunction, nameOf, prototypeOf, Store, Type} from "@tsed/core";
-import {getOperationsStores, JsonEntityComponent, JsonEntityStore, JsonEntityStoreOptions, JsonOperation, JsonResponse} from "@tsed/schema";
+import {getOperationsStores, JsonEntityComponent, JsonEntityStore, JsonEntityStoreOptions, JsonOperation} from "@tsed/schema";
 import {ParamMetadata} from "./ParamMetadata";
 
 export interface EndpointConstructorOptions extends JsonEntityStoreOptions {
@@ -96,6 +96,14 @@ export class EndpointMetadata extends JsonEntityStore implements EndpointConstru
 
   set location(url: string) {
     this.store.set("location", url);
+  }
+
+  get acceptMimes(): string[] {
+    return this.store.get<string[]>("acceptMimes", []);
+  }
+
+  set acceptMimes(mimes: string[]) {
+    this.store.set("acceptMimes", mimes);
   }
 
   get redirect(): EndpointRedirectOptions {

--- a/packages/common/src/platform/builder/PlatformControllerBuilder.spec.ts
+++ b/packages/common/src/platform/builder/PlatformControllerBuilder.spec.ts
@@ -5,6 +5,7 @@ import {expect} from "chai";
 import * as Sinon from "sinon";
 import {stub} from "../../../../../test/helper/tools";
 import {EndpointMetadata} from "../../mvc/models/EndpointMetadata";
+import {PlatformAcceptMimesMiddleware} from "../middlewares/PlatformAcceptMimesMiddleware";
 import {Platform} from "../services/Platform";
 import {PlatformApplication} from "../services/PlatformApplication";
 import {PlatformHandler} from "../services/PlatformHandler";
@@ -111,6 +112,7 @@ describe("PlatformControllerBuilder", () => {
     expect(router.get).to.have.been.calledWithExactly(
       "/",
       Sinon.match.func,
+      PlatformAcceptMimesMiddleware,
       provider.middlewares.use[0],
       endpoint.beforeMiddlewares[0],
       endpoint.middlewares[0],
@@ -136,6 +138,7 @@ describe("PlatformControllerBuilder", () => {
     expect(router.use.getCall(1)).to.have.been.calledWithExactly(
       "/",
       Sinon.match.func,
+      PlatformAcceptMimesMiddleware,
       provider.middlewares.use[0],
       endpoint.beforeMiddlewares[0],
       endpoint.middlewares[0],
@@ -160,6 +163,7 @@ describe("PlatformControllerBuilder", () => {
     // ENDPOINT
     expect(router.use.getCall(1)).to.have.been.calledWithExactly(
       Sinon.match.func,
+      PlatformAcceptMimesMiddleware,
       provider.middlewares.use[0],
       endpoint.beforeMiddlewares[0],
       endpoint.middlewares[0],
@@ -191,7 +195,7 @@ describe("PlatformControllerBuilder", () => {
     // THEN
     expect(result).to.be.instanceof(PlatformRouter);
     // ENDPOINT
-    expect(router.use.getCall(0)).to.have.been.calledWithExactly("/", Sinon.match.func, endpointAll);
-    expect(router.use.getCall(1)).to.have.been.calledWithExactly("/", Sinon.match.func, endpoint);
+    expect(router.use.getCall(0)).to.have.been.calledWithExactly("/", Sinon.match.func, PlatformAcceptMimesMiddleware, endpointAll);
+    expect(router.use.getCall(1)).to.have.been.calledWithExactly("/", Sinon.match.func, PlatformAcceptMimesMiddleware, endpoint);
   });
 });

--- a/packages/common/src/platform/builder/PlatformControllerBuilder.ts
+++ b/packages/common/src/platform/builder/PlatformControllerBuilder.ts
@@ -5,6 +5,7 @@ import {EndpointMetadata} from "../../mvc/models/EndpointMetadata";
 import {ControllerProvider} from "../domain/ControllerProvider";
 import {PlatformRouterMethods} from "../interfaces/PlatformRouterMethods";
 import {bindEndpointMiddleware} from "../middlewares/bindEndpointMiddleware";
+import {PlatformAcceptMimesMiddleware} from "../middlewares/PlatformAcceptMimesMiddleware";
 import {PlatformRouter} from "../services/PlatformRouter";
 import {useCtxHandler} from "../utils/useCtxHandler";
 
@@ -89,6 +90,7 @@ export class PlatformControllerBuilder {
 
     handlers = handlers
       .concat(useCtxHandler(bindEndpointMiddleware(endpoint)))
+      .concat(PlatformAcceptMimesMiddleware)
       .concat(use) // Controller use-middlewares
       .concat(beforeMiddlewares) // Endpoint before-middlewares
       .concat(mldwrs) // Endpoint middlewares

--- a/packages/common/src/platform/index.ts
+++ b/packages/common/src/platform/index.ts
@@ -14,10 +14,11 @@ export * from "./interfaces/IRoute";
 export * from "./interfaces/PlatformRouterMethods";
 
 // middlewares
+export * from "./middlewares/bindEndpointMiddleware";
 export * from "./middlewares/PlatformLogMiddleware";
 export * from "./middlewares/PlatformMulterMiddleware";
-export * from "./middlewares/bindEndpointMiddleware";
 export * from "./middlewares/GlobalAcceptMimesMiddleware";
+export * from "./middlewares/PlatformAcceptMimesMiddleware";
 
 // domain
 export * from "./domain/HandlerContext";

--- a/packages/common/src/platform/middlewares/GlobalAcceptMimesMiddleware.spec.ts
+++ b/packages/common/src/platform/middlewares/GlobalAcceptMimesMiddleware.spec.ts
@@ -1,8 +1,6 @@
 import {PlatformRequest, PlatformTest} from "@tsed/common";
-import {catchError} from "@tsed/core";
 import {expect} from "chai";
 import {FakeRequest} from "../../../../../test/helper";
-import {PlatformConfiguration} from "../../config";
 import {GlobalAcceptMimesMiddleware} from "./GlobalAcceptMimesMiddleware";
 
 describe("GlobalAcceptMimesMiddleware", () => {
@@ -20,35 +18,9 @@ describe("GlobalAcceptMimesMiddleware", () => {
         request: new PlatformRequest(request)
       });
 
-      const settings = new PlatformConfiguration();
-      settings.acceptMimes = ["application/json"];
-
-      const middleware = new GlobalAcceptMimesMiddleware(settings as any);
+      const middleware = new GlobalAcceptMimesMiddleware();
 
       expect(middleware.use(context)).to.eq(undefined);
-    });
-  });
-
-  describe("not accept", () => {
-    it("should throws NotAcceptable", () => {
-      const request: any = new FakeRequest({
-        headers: {
-          accept: "text/html"
-        }
-      });
-
-      const context = PlatformTest.createRequestContext({
-        request: new PlatformRequest(request)
-      });
-
-      const settings = new PlatformConfiguration();
-      settings.acceptMimes = ["application/json"];
-
-      const middleware = new GlobalAcceptMimesMiddleware(settings as any);
-
-      const error: any = catchError(() => middleware.use(context));
-
-      expect(error.message).to.eq("You must accept content-type application/json");
     });
   });
 });

--- a/packages/common/src/platform/middlewares/GlobalAcceptMimesMiddleware.ts
+++ b/packages/common/src/platform/middlewares/GlobalAcceptMimesMiddleware.ts
@@ -1,20 +1,13 @@
-import {Configuration} from "@tsed/di";
-import {NotAcceptable} from "@tsed/exceptions";
 import {IMiddleware, Middleware} from "../../mvc";
 import {Context} from "../decorators/context";
 
 /**
- * @middleware
+ * @deprecated Since 2020-11-30. Use PlatformAcceptMimesMiddleware.
+ * @ignore
  */
 @Middleware()
 export class GlobalAcceptMimesMiddleware implements IMiddleware {
-  constructor(@Configuration() private configuration: Configuration) {}
-
   use(@Context() ctx: Context) {
-    const {request} = ctx;
-
-    if (this.configuration.acceptMimes?.length && !request.accepts(this.configuration.acceptMimes)) {
-      throw new NotAcceptable(this.configuration.acceptMimes.join(", "));
-    }
+    return;
   }
 }

--- a/packages/common/src/platform/middlewares/PlatformAcceptMimesMiddleware.spec.ts
+++ b/packages/common/src/platform/middlewares/PlatformAcceptMimesMiddleware.spec.ts
@@ -1,0 +1,190 @@
+import {AcceptMime, EndpointMetadata, Get, PlatformRequest, PlatformTest} from "@tsed/common";
+import {catchError} from "@tsed/core";
+import {expect} from "chai";
+import * as Sinon from "sinon";
+import {FakeRequest} from "../../../../../test/helper";
+import {PlatformAcceptMimesMiddleware} from "./PlatformAcceptMimesMiddleware";
+
+const sandbox = Sinon.createSandbox();
+
+describe("PlatformMimesMiddleware", () => {
+  describe("when server has configuration", () => {
+    beforeEach(() =>
+      PlatformTest.create({
+        acceptMimes: ["application/json", "text"]
+      })
+    );
+    afterEach(() => PlatformTest.reset());
+    it("should accept type (application/json)", async () => {
+      class Test {
+        @Get("/")
+        @AcceptMime("application/json")
+        get() {}
+      }
+
+      const endpoint = EndpointMetadata.get(Test, "get");
+      const request: any = new FakeRequest({
+        sandbox,
+        headers: {
+          accept: "application/json"
+        }
+      });
+      const ctx = PlatformTest.createRequestContext({
+        request: new PlatformRequest(request),
+        endpoint
+      });
+
+      const middleware = await PlatformTest.invoke<PlatformAcceptMimesMiddleware>(PlatformAcceptMimesMiddleware);
+      middleware.use(ctx);
+
+      expect(request.accepts).to.have.been.calledWithExactly(["application/json", "text"]);
+    });
+    it("should accept type (text)", async () => {
+      class Test {
+        @Get("/")
+        @AcceptMime("text")
+        get() {}
+      }
+
+      const endpoint = EndpointMetadata.get(Test, "get");
+      const request: any = new FakeRequest({
+        sandbox,
+        headers: {
+          accept: "text/*, application/json"
+        }
+      });
+      const ctx = PlatformTest.createRequestContext({
+        request: new PlatformRequest(request),
+        endpoint
+      });
+
+      const middleware = await PlatformTest.invoke<PlatformAcceptMimesMiddleware>(PlatformAcceptMimesMiddleware);
+      middleware.use(ctx);
+
+      expect(request.accepts).to.have.been.calledWithExactly(["text", "application/json"]);
+    });
+    it("should refuse type", async () => {
+      class Test {
+        @Get("/")
+        @AcceptMime("application/json")
+        get() {}
+      }
+
+      const endpoint = EndpointMetadata.get(Test, "get");
+      const request: any = new FakeRequest({
+        sandbox,
+        headers: {
+          accept: "application/xml"
+        }
+      });
+      const ctx = PlatformTest.createRequestContext({
+        request: new PlatformRequest(request),
+        endpoint
+      });
+      const middleware = await PlatformTest.invoke<PlatformAcceptMimesMiddleware>(PlatformAcceptMimesMiddleware);
+
+      const error: any = catchError(() => middleware.use(ctx));
+
+      expect(error.message).to.equal("You must accept content-type application/json, text");
+    });
+  });
+  describe("when server hasn't configuration", () => {
+    beforeEach(() => PlatformTest.create());
+    afterEach(() => PlatformTest.reset());
+    it("should do noting", async () => {
+      class Test {
+        @Get("/")
+        get() {}
+      }
+
+      const endpoint = EndpointMetadata.get(Test, "get");
+      const request: any = new FakeRequest({
+        sandbox,
+        headers: {
+          accept: "application/json"
+        }
+      });
+      const ctx = PlatformTest.createRequestContext({
+        request: new PlatformRequest(request),
+        endpoint
+      });
+
+      const middleware = await PlatformTest.invoke<PlatformAcceptMimesMiddleware>(PlatformAcceptMimesMiddleware);
+      middleware.use(ctx);
+
+      return expect(request.accepts).to.not.have.been.called;
+    });
+    it("should accept type (application/json)", async () => {
+      class Test {
+        @Get("/")
+        @AcceptMime("application/json")
+        get() {}
+      }
+
+      const endpoint = EndpointMetadata.get(Test, "get");
+      const request: any = new FakeRequest({
+        sandbox,
+        headers: {
+          accept: "application/json"
+        }
+      });
+      const ctx = PlatformTest.createRequestContext({
+        request: new PlatformRequest(request),
+        endpoint
+      });
+
+      const middleware = await PlatformTest.invoke<PlatformAcceptMimesMiddleware>(PlatformAcceptMimesMiddleware);
+      middleware.use(ctx);
+
+      expect(request.accepts).to.have.been.calledWithExactly(["application/json"]);
+    });
+    it("should accept type (text)", async () => {
+      class Test {
+        @Get("/")
+        @AcceptMime("text")
+        get() {}
+      }
+
+      const endpoint = EndpointMetadata.get(Test, "get");
+      const request: any = new FakeRequest({
+        sandbox,
+        headers: {
+          accept: "text/*, application/json"
+        }
+      });
+      const ctx = PlatformTest.createRequestContext({
+        request: new PlatformRequest(request),
+        endpoint
+      });
+
+      const middleware = await PlatformTest.invoke<PlatformAcceptMimesMiddleware>(PlatformAcceptMimesMiddleware);
+      middleware.use(ctx);
+
+      expect(request.accepts).to.have.been.calledWithExactly(["text"]);
+    });
+    it("should refuse type", async () => {
+      class Test {
+        @Get("/")
+        @AcceptMime("application/json")
+        get() {}
+      }
+
+      const endpoint = EndpointMetadata.get(Test, "get");
+      const request: any = new FakeRequest({
+        sandbox,
+        headers: {
+          accept: "application/xml"
+        }
+      });
+      const ctx = PlatformTest.createRequestContext({
+        request: new PlatformRequest(request),
+        endpoint
+      });
+      const middleware = await PlatformTest.invoke<PlatformAcceptMimesMiddleware>(PlatformAcceptMimesMiddleware);
+
+      const error: any = catchError(() => middleware.use(ctx));
+
+      expect(error.message).to.equal("You must accept content-type application/json");
+    });
+  });
+});

--- a/packages/common/src/platform/middlewares/PlatformAcceptMimesMiddleware.ts
+++ b/packages/common/src/platform/middlewares/PlatformAcceptMimesMiddleware.ts
@@ -1,0 +1,24 @@
+import {uniq} from "@tsed/core";
+import {Constant} from "@tsed/di";
+import {NotAcceptable} from "@tsed/exceptions";
+import {IMiddleware, Middleware} from "../../mvc";
+import {Context} from "../decorators/context";
+
+/**
+ * @middleware
+ * @platform
+ */
+@Middleware()
+export class PlatformAcceptMimesMiddleware implements IMiddleware {
+  @Constant("acceptMimes", [])
+  acceptMimes: string[];
+
+  public use(@Context() ctx: Context): void {
+    const {endpoint, request} = ctx;
+    const mimes = uniq((endpoint.get("acceptMimes") || []).concat(this.acceptMimes));
+
+    if (mimes.length && !request.accepts(mimes)) {
+      throw new NotAcceptable(mimes.join(", "));
+    }
+  }
+}

--- a/packages/platform-test-utils/src/tests/testAcceptMime.ts
+++ b/packages/platform-test-utils/src/tests/testAcceptMime.ts
@@ -1,4 +1,5 @@
-import {AcceptMime, Controller, HeaderParams, PlatformTest, Post} from "@tsed/common";
+import {AcceptMime, Controller, Get, HeaderParams, PlatformTest, Post} from "@tsed/common";
+import {ContentType} from "@tsed/schema";
 import {expect} from "chai";
 import * as SuperTest from "supertest";
 import {PlatformTestOptions} from "../interfaces";
@@ -11,6 +12,13 @@ class TestAcceptMimeCtrl {
     return {
       accept
     };
+  }
+
+  @Get("/scenario-2")
+  @ContentType("text")
+  @AcceptMime("text")
+  public ping() {
+    return "pong";
   }
 }
 
@@ -53,6 +61,33 @@ export function testAcceptMime(options: PlatformTestOptions) {
       expect(response.body).to.deep.equal({
         name: "NOT_ACCEPTABLE",
         message: "You must accept content-type application/json",
+        status: 406,
+        errors: []
+      });
+    });
+  });
+  describe("Scenario 2: GET /rest/accept-mime/scenario-2", () => {
+    it('should return a 200 response when Accept header match with @AcceptMime("text")', async () => {
+      const response = await request
+        .get("/rest/accept-mime/scenario-2")
+        .set({
+          Accept: "text/*, application/json"
+        })
+        .expect(200);
+
+      expect(response.text).to.equal("pong");
+    });
+    it('should return a 406 response when Accept header doesn\'t match with @AcceptMime("text")', async () => {
+      const response = await request
+        .get("/rest/accept-mime/scenario-2")
+        .set({
+          Accept: "application/xml"
+        })
+        .expect(406);
+
+      expect(response.body).to.deep.equal({
+        name: "NOT_ACCEPTABLE",
+        message: "You must accept content-type text",
         status: 406,
         errors: []
       });

--- a/test/helper/FakeRequest.ts
+++ b/test/helper/FakeRequest.ts
@@ -2,6 +2,8 @@ import {PlatformContext} from "@tsed/common/src/platform/domain/PlatformContext"
 import * as Sinon from "sinon";
 import {SinonStub} from "sinon";
 
+const accepts = require("accepts");
+
 export class FakeRequest {
   public url = "/";
   public method: string;
@@ -59,7 +61,7 @@ export class FakeRequest {
     accept: "application/json"
   };
   public $ctx: PlatformContext;
-  public log: {[key: string]: SinonStub};
+  public log: { [key: string]: SinonStub };
   public isAuthenticated: SinonStub;
 
   [key: string]: any;
@@ -102,8 +104,6 @@ export class FakeRequest {
   }
 
   accepts(mime?: string | string[]) {
-    mime = [].concat(mime as any) as string[];
-
-    return mime.find((m: string) => m === this.headers.accept);
+    return accepts(this).types([].concat(mime as never));
   }
 }


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

****

## Description
Fix conflict between GlobalAcceptMimesMiddleware and AcceptMimesMiddleware.
Now, Ts.ED will use only one middleware to check the acceptable mimes (with PlatformAcceptMimesMiddleware).
