### PR TITLE
docs: Fix getting started link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Documentation is available on [https://tsed.io](https://tsed.io)
 
 ## Getting started 
 
-See our [getting started here](https://tsed.io/getting-started.html) to create new Ts.ED project or use
+See our [getting started here](https://tsed.io/getting-started) to create new Ts.ED project or use
 our [CLI](https://cli.tsed.io)
 
 ## Examples


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Doc | No

****

## Description
Fix the getting started link. The current link is https://tsed.io/getting-started.html which response with a 404. I updated it with https://tsed.io/getting-started.


