### PR TITLE
Fix 1222 response filter

### DIFF
--- a/packages/common/src/platform-response-filter/services/PlatformResponseFilter.ts
+++ b/packages/common/src/platform-response-filter/services/PlatformResponseFilter.ts
@@ -62,7 +62,7 @@ export class PlatformResponseFilter {
       const bestContentType = ctx.request.accepts([contentType].concat(this.contentTypes).filter(Boolean));
 
       if (bestContentType) {
-        return [].concat(bestContentType as any)[0];
+        return [].concat(bestContentType as any).filter((type) => type !== "*/*")[0];
       }
     }
 

--- a/packages/platform-express/test/plainText.spec.ts
+++ b/packages/platform-express/test/plainText.spec.ts
@@ -17,11 +17,18 @@ const utils = PlatformTestUtils.create({
 
 @Controller("/plain-text")
 class TestResponseParamsCtrl {
-  @Get("/scenario14")
+  @Get("/scenario-1")
   @(Returns(200, String).ContentType("text/plain"))
   test() {
     return {
       id: "id"
+    };
+  }
+
+  @Get("/scenario-2")
+  public scenario8() {
+    return {
+      jsonexample: 1
     };
   }
 }
@@ -39,43 +46,22 @@ describe("PlainText", () => {
   });
 
   afterEach(utils.reset);
-  describe("plain/text", () => {
-    it("should text", async () => {
-      const spec = getSpec(TestResponseParamsCtrl, {specType: SpecTypes.OPENAPI});
-      const response = await request.get("/rest/plain-text/scenario14");
+  describe("scenario 1", () => {
+    it("should return a plain text", async () => {
+      const response = await request.get("/rest/plain-text/scenario-1");
 
-      expect(spec).to.deep.eq({
-        "paths": {
-          "/plain-text/scenario14": {
-            "get": {
-              "operationId": "testResponseParamsCtrlTest",
-              "parameters": [],
-              "responses": {
-                "200": {
-                  "content": {
-                    "text/plain": {
-                      "schema": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "Success"
-                }
-              },
-              "tags": [
-                "TestResponseParamsCtrl"
-              ]
-            }
-          }
-        },
-        "tags": [
-          {
-            "name": "TestResponseParamsCtrl"
-          }
-        ]
-      });
       expect(response.headers["content-type"]).to.equal("text/plain; charset=utf-8");
       expect(response.text).to.equal("{\"id\":\"id\"}");
+    });
+  });
+  describe("scenario 2", () => {
+    it("should return a */* content-type", async () => {
+      const response = await request.get("/rest/plain-text/scenario-2").set("Accept", "*/*").set("Content-Type", "application/json").expect(200);
+
+      expect(response.headers["content-type"]).to.equal("application/json; charset=utf-8");
+      expect(response.body).to.deep.equal({
+        jsonexample: 1
+      });
     });
   });
 });

--- a/packages/platform-test-utils/src/tests/testResponse.ts
+++ b/packages/platform-test-utils/src/tests/testResponse.ts
@@ -155,6 +155,13 @@ class TestResponseParamsCtrl {
 
     return image_res.body;
   }
+
+  @Get("/scenario14")
+  public scenario14() {
+    return {
+      jsonexample: 1
+    };
+  }
 }
 
 export function testResponse(options: PlatformTestOptions) {
@@ -337,6 +344,21 @@ export function testResponse(options: PlatformTestOptions) {
       expect(response.headers["content-disposition"]).to.equal("inline;filename=googlelogo_color_272x92dp.png;");
       expect(response.headers["content-type"]).to.contains("image/png");
       expect(response.headers["content-length"]).to.equal("5969");
+    });
+  });
+
+  describe("Scenario13: Return application/json when Accept is */*", () => {
+    it("should return a */* content-type", async () => {
+      const response = await request
+        .get("/rest/response/scenario14")
+        .set("Accept", "*/*")
+        .set("Content-Type", "application/json")
+        .expect(200);
+
+      expect(response.headers["content-type"]).to.equal("application/json; charset=utf-8");
+      expect(response.body).to.deep.equal({
+        jsonexample: 1
+      });
     });
   });
 }


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

Ts.ED consume the accept header to find the best content-type. But if accept is */*, the content-type response isn't correctly applied. This fix solve the issue and let Express/Koa to decide to apply the best content-type based on the response data.

See: https://github.com/Romakita/tsed-issue-1222/issues/1