### PR TITLE
fix: call to deprecated shouldValidate method

### DIFF
--- a/docs/docs/snippets/validation/class-validator-pipe.ts
+++ b/docs/docs/snippets/validation/class-validator-pipe.ts
@@ -22,6 +22,6 @@ export class ClassValidationPipe extends ValidationPipe implements IPipe<any> {
   protected shouldValidate(metadata: ParamMetadata): boolean {
     const types: Function[] = [String, Boolean, Number, Array, Object];
 
-    return !super.shouldValidate(metadata) || !types.includes(metadata.type);
+    return !(metadata.type || metadata.collectionType) || !types.includes(metadata.type);
   }
 }


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

****

## Description
Fix a call to a missing deprecated method in class validation pipe

