### PR TITLE
Fix mongoose circular ref

### DIFF
--- a/packages/mongoose/src/decorators/ref.ts
+++ b/packages/mongoose/src/decorators/ref.ts
@@ -1,6 +1,6 @@
 import {isArrowFn, isString, StoreMerge, Type, useDecorators} from "@tsed/core";
 import {OnDeserialize, OnSerialize, serialize} from "@tsed/json-mapper";
-import {JsonEntityFn, JsonEntityStore, Property, string} from "@tsed/schema";
+import {JsonEntityFn, lazyRef, Property, string} from "@tsed/schema";
 import {Schema as MongooseSchema} from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";
 import {MongooseSchemaTypes} from "../interfaces/MongooseSchemaTypes";
@@ -63,13 +63,8 @@ export function Ref(model: string | (() => Type) | any, type: MongooseSchemaType
 
       return serialize(value, {...ctx, type});
     }),
-    JsonEntityFn((store) => {
-      const type = getType();
-
-      store.itemSchema.oneOf([
-        string().example("5ce7ad3028890bd71749d477").description("Mongoose Ref ObjectId"),
-        JsonEntityStore.from(type).schema as any
-      ]);
+    JsonEntityFn(async (store) => {
+      store.itemSchema.oneOf([string().example("5ce7ad3028890bd71749d477").description("Mongoose Ref ObjectId"), lazyRef(getType)]);
 
       store.type = Object;
     })

--- a/packages/mongoose/src/decorators/schema.ts
+++ b/packages/mongoose/src/decorators/schema.ts
@@ -1,9 +1,10 @@
-import {Property} from "@tsed/schema";
 import {decoratorTypeOf, StoreMerge, useDecorators} from "@tsed/core";
+import {registerProvider} from "@tsed/di";
+import {Property} from "@tsed/schema";
 import {SchemaTypeOptions} from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";
 import {MongooseSchemaOptions} from "../interfaces";
-import {createSchema} from "../utils/createSchema";
+import {getSchema, getSchemaToken} from "../utils/createSchema";
 
 /**
  * Define a class as a Mongoose Schema ready to be used to compose other schemes and models.
@@ -38,7 +39,15 @@ export function Schema(options: MongooseSchemaOptions | SchemaTypeOptions<any> =
         return useDecorators(Property(), StoreMerge(MONGOOSE_SCHEMA, options))(parameters[0], parameters[1], parameters[2]);
 
       case "class":
-        StoreMerge(MONGOOSE_SCHEMA, createSchema(parameters[0], options as MongooseSchemaOptions))(...parameters);
+        const {token} = getSchemaToken(parameters[0], options);
+
+        registerProvider({
+          provide: token,
+          deps: [],
+          useFactory() {
+            return getSchema(parameters[0], options as any);
+          }
+        });
         break;
     }
   };

--- a/packages/mongoose/src/utils/createModel.ts
+++ b/packages/mongoose/src/utils/createModel.ts
@@ -1,6 +1,17 @@
-import {nameOf} from "@tsed/core";
-import mongoose from "mongoose";
-import {Connection} from "mongoose";
+import {nameOf, Store, Type} from "@tsed/core";
+import mongoose, {Connection} from "mongoose";
+import {MONGOOSE_MODEL_NAME} from "../constants";
+import {MongooseModels} from "../registries/MongooseModels";
+import {getSchemaToken} from "./createSchema";
+
+export function getModelToken(target: Type<any>, options: any) {
+  const {collectionName, token} = getSchemaToken(target, options);
+
+  Store.from(target).set(MONGOOSE_MODEL_NAME, collectionName);
+  MongooseModels.set(collectionName, target);
+
+  return {token, collectionName};
+}
 
 /**
  * Create an instance of mongoose.model from a class.

--- a/packages/mongoose/src/utils/createSchema.spec.ts
+++ b/packages/mongoose/src/utils/createSchema.spec.ts
@@ -594,11 +594,12 @@ describe("createSchema", () => {
         enum: MyEnum;
       }
 
-      @Model()
-      class Test9 {
+      class TestWithSet9 {
         @CollectionOf(Children)
         tests: Set<Children>;
       }
+
+      getSchema(TestWithSet9);
     } catch (er) {
       actualError = er;
     }

--- a/packages/mongoose/src/utils/createSchema.ts
+++ b/packages/mongoose/src/utils/createSchema.ts
@@ -1,6 +1,8 @@
-import {cleanObject, Store, Type} from "@tsed/core";
+import {cleanObject, nameOf, Store, Type} from "@tsed/core";
+import {registerProvider} from "@tsed/di";
 import {deserialize, serialize} from "@tsed/json-mapper";
 import {getProperties, JsonEntityStore} from "@tsed/schema";
+import {pascalCase} from "change-case";
 import mongoose, {Schema, SchemaDefinition, SchemaOptions, SchemaTypeOptions} from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";
 import {MongooseSchemaOptions} from "../interfaces";
@@ -61,6 +63,8 @@ export function createSchema(target: Type<any>, options: MongooseSchemaOptions =
 
   schema.loadClass(target);
 
+  Store.from(target).set(MONGOOSE_SCHEMA, schema);
+
   return schema;
 }
 
@@ -73,10 +77,17 @@ export function getSchema(target: Type<any>, options: MongooseSchemaOptions = {}
   const store = Store.from(target);
 
   if (!store.has(MONGOOSE_SCHEMA)) {
-    store.set(MONGOOSE_SCHEMA, createSchema(target, options));
+    createSchema(target, options);
   }
 
   return store.get(MONGOOSE_SCHEMA);
+}
+
+export function getSchemaToken(target: Type<any>, options?: any) {
+  const collectionName = options.name || nameOf(target);
+  const token = Symbol.for(pascalCase(`${collectionName}Schema`));
+
+  return {token, collectionName};
 }
 
 /**

--- a/packages/mongoose/test/circularRef.integration.spec.ts
+++ b/packages/mongoose/test/circularRef.integration.spec.ts
@@ -1,0 +1,115 @@
+import {Injectable, PlatformTest} from "@tsed/common";
+import {Inject} from "@tsed/di";
+import {getJsonSchema} from "@tsed/schema/src";
+import {TestMongooseContext} from "@tsed/testing-mongoose";
+import {expect} from "chai";
+import {MongooseModel} from "../src";
+import {TestContract} from "./helpers/models/Contract";
+import {TestCustomer} from "./helpers/models/Customer";
+
+@Injectable()
+class MyService {
+  @Inject(TestContract)
+  contract: MongooseModel<TestContract>;
+
+  @Inject(TestCustomer)
+  customer: MongooseModel<TestCustomer>;
+}
+
+describe("Circular Ref", () => {
+  beforeEach(TestMongooseContext.create);
+  afterEach(TestMongooseContext.reset);
+  it("should load models with his schema", async () => {
+    const service = await PlatformTest.invoke<MyService>(MyService);
+
+    expect(!!service.contract).to.be.true;
+    expect(!!service.customer).to.be.true;
+
+    expect(getJsonSchema(TestContract)).to.deep.equal({
+      "definitions": {
+        "TestContract": {
+          "properties": {
+            "_id": {
+              "description": "Mongoose ObjectId",
+              "examples": [
+                "5ce7ad3028890bd71749d477"
+              ],
+              "pattern": "^[0-9a-fA-F]{24}$",
+              "type": "string"
+            },
+            "customer": {
+              "oneOf": [
+                {
+                  "description": "Mongoose Ref ObjectId",
+                  "examples": [
+                    "5ce7ad3028890bd71749d477"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/TestCustomer"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "TestCustomer": {
+          "properties": {
+            "_id": {
+              "description": "Mongoose ObjectId",
+              "examples": [
+                "5ce7ad3028890bd71749d477"
+              ],
+              "pattern": "^[0-9a-fA-F]{24}$",
+              "type": "string"
+            },
+            "contracts": {
+              "items": {
+                "oneOf": [
+                  {
+                    "description": "Mongoose Ref ObjectId",
+                    "examples": [
+                      "5ce7ad3028890bd71749d477"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/TestContract"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "properties": {
+        "_id": {
+          "description": "Mongoose ObjectId",
+          "examples": [
+            "5ce7ad3028890bd71749d477"
+          ],
+          "pattern": "^[0-9a-fA-F]{24}$",
+          "type": "string"
+        },
+        "customer": {
+          "oneOf": [
+            {
+              "description": "Mongoose Ref ObjectId",
+              "examples": [
+                "5ce7ad3028890bd71749d477"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TestCustomer"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    });
+  });
+});

--- a/packages/mongoose/test/helpers/models/Contract.ts
+++ b/packages/mongoose/test/helpers/models/Contract.ts
@@ -1,0 +1,11 @@
+import {Model, ObjectID, Ref} from "../../../src";
+import {TestCustomer} from "./Customer";
+
+@Model({name: "testContract", schemaOptions: {timestamps: true}})
+export class TestContract {
+  @ObjectID()
+  _id: string;
+
+  @Ref(() => TestCustomer)
+  customer: Ref<TestCustomer>;
+}

--- a/packages/mongoose/test/helpers/models/Customer.ts
+++ b/packages/mongoose/test/helpers/models/Customer.ts
@@ -1,0 +1,13 @@
+import {Model, ObjectID, Ref} from "@tsed/mongoose";
+import {CollectionOf} from "@tsed/schema";
+import {TestContract} from "./Contract";
+
+@Model({name: "testCustomer", schemaOptions: {timestamps: true}})
+export class TestCustomer {
+  @ObjectID()
+  _id: string;
+
+  @Ref(() => TestContract)
+  @CollectionOf(() => TestContract)
+  contracts?: Ref<TestContract>[];
+}

--- a/packages/mongoose/test/subdocument.integration.spec.ts
+++ b/packages/mongoose/test/subdocument.integration.spec.ts
@@ -1,0 +1,37 @@
+import {Property} from "@tsed/schema";
+import {TestMongooseContext} from "@tsed/testing-mongoose";
+import { expect } from 'chai';
+import {getSchema, Model, MongooseSchema, ObjectID} from "../src";
+
+@MongooseSchema()
+export class TestSubDocument {
+  @Property()
+  prop: string;
+}
+
+@Model()
+export class TestModelDocument {
+  @ObjectID()
+  _id: string;
+
+  @Property()
+  sub: TestSubDocument;
+}
+
+describe("Mongoose", () => {
+  describe("SubDocument", () => {
+    beforeEach(TestMongooseContext.create);
+    afterEach(TestMongooseContext.reset);
+
+    it(
+      "should create model with sub document",
+      () => {
+        const documentSchema = getSchema(TestModelDocument);
+        const subDocumentSchema = getSchema(TestSubDocument);
+
+        expect(documentSchema.obj.sub.type.obj.prop.type).to.equal(String)
+        expect(documentSchema.obj.sub.type).to.equal(subDocumentSchema)
+        expect(subDocumentSchema.obj.prop.type).to.equal(String)
+      });
+  });
+});

--- a/packages/schema/src/domain/JsonLazyRef.ts
+++ b/packages/schema/src/domain/JsonLazyRef.ts
@@ -1,0 +1,24 @@
+import {nameOf, Type} from "@tsed/core";
+import {JsonSchemaOptions} from "../interfaces/JsonSchemaOptions";
+import {serializeJsonSchema} from "../utils/serializeJsonSchema";
+import {JsonEntityStore} from "./JsonEntityStore";
+
+export class JsonLazyRef {
+  constructor(readonly getType: () => Type<any>) {}
+
+  get target() {
+    return this.getType();
+  }
+
+  get schema() {
+    return JsonEntityStore.from(this.getType()).schema;
+  }
+
+  get name() {
+    return nameOf(this.getType());
+  }
+
+  toJSON(options?: JsonSchemaOptions) {
+    return this.getType() && serializeJsonSchema(this.schema, options);
+  }
+}

--- a/packages/schema/src/domain/JsonSchema.ts
+++ b/packages/schema/src/domain/JsonSchema.ts
@@ -9,6 +9,7 @@ import {serializeJsonSchema} from "../utils/serializeJsonSchema";
 import {toJsonRegex} from "../utils/toJsonRegex";
 import {AliasMap, AliasType} from "./JsonAliasMap";
 import {JsonFormatTypes} from "./JsonFormatTypes";
+import {JsonLazyRef} from "./JsonLazyRef";
 import {SpecTypes} from "./SpecTypes";
 
 export interface JsonSchemaObject extends JSONSchema6 {
@@ -27,7 +28,15 @@ function mapToJsonSchema(item: any): any {
     return (item as any[]).map(mapToJsonSchema);
   }
 
-  return item instanceof JsonSchema ? item : JsonSchema.from(item as any);
+  if (item instanceof JsonSchema) {
+    return item;
+  }
+
+  if (item instanceof JsonLazyRef) {
+    return item;
+  }
+
+  return JsonSchema.from(item as any);
 }
 
 function mapProperties(properties: {[p: string]: any}) {
@@ -514,7 +523,7 @@ export class JsonSchema extends Map<string, any> implements NestedGenerics {
   /**
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.28
    */
-  oneOf(oneOf: (JsonSchemaObject | JsonSchema)[]) {
+  oneOf(oneOf: (JsonSchemaObject | JsonSchema | JsonLazyRef | any)[]) {
     super.set("oneOf", oneOf.map(mapToJsonSchema));
 
     return this;

--- a/packages/schema/src/domain/index.ts
+++ b/packages/schema/src/domain/index.ts
@@ -8,3 +8,4 @@ export * from "./JsonFormatTypes";
 export * from "./SpecTypes";
 export * from "./JsonEntityStore";
 export * from "./JsonParameterTypes";
+export * from "./JsonLazyRef";

--- a/packages/schema/src/utils/from.ts
+++ b/packages/schema/src/utils/from.ts
@@ -1,5 +1,6 @@
 import {isClass, Type} from "@tsed/core";
 import {JsonEntityStore, JsonFormatTypes} from "../domain";
+import {JsonLazyRef} from "../domain/JsonLazyRef";
 import {JsonSchema} from "../domain/JsonSchema";
 
 /**
@@ -250,4 +251,17 @@ export function oneOf(...oneOf: any[]) {
  */
 export function allOf(...allOf: any[]) {
   return from().allOf(allOf);
+}
+/**
+ * Declare a sub schema which will be resolved later. Use this function when you have a circular reference between two schemes.
+ *
+ * @schemaFunctional
+ */
+export function lazyRef(cb: () => Type<any>) {
+  if (cb()) {
+    // type is already accessible
+    return JsonEntityStore.from(cb()).schema as any;
+  }
+
+  return new JsonLazyRef(cb);
 }


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

Fix issue when using two classes which reference each other.

```typescript
import {Model, ObjectID, Ref} from "../../../src";
import {TestCustomer} from "./Customer";

@Model({name: "testContract", schemaOptions: {timestamps: true}})
export class TestContract {
  @ObjectID()
  _id: string;

  @Ref(() => TestCustomer)
  customer: Ref<TestCustomer>;
} 
```

```typescript
import {Model, ObjectID, Ref} from "@tsed/mongoose";
import {CollectionOf} from "@tsed/schema";
import {TestContract} from "./Contract";

@Model({name: "testCustomer", schemaOptions: {timestamps: true}})
export class TestCustomer {
  @ObjectID()
  _id: string;

  @Ref(() => TestContract)
  @CollectionOf(() => TestContract)
  contracts?: Ref<TestContract>[];
}
```