### PR TITLE
Fix import error and deprecated method in example

### DIFF
--- a/docs/tutorials/snippets/passport/acceptRoles.ts
+++ b/docs/tutorials/snippets/passport/acceptRoles.ts
@@ -1,9 +1,9 @@
-import {UseBefore} from "@tsed/common/src";
-import {applyDecorators, StoreSet} from "@tsed/core";
+import {UseBefore} from "@tsed/common";
+import {useDecorators, StoreSet} from "@tsed/core";
 import {AcceptRolesMiddleware} from "./AcceptRolesMiddleware";
 
 export function AcceptRoles(...roles: string[]) {
-  return applyDecorators(
+  return useDecorators(
     UseBefore(AcceptRolesMiddleware),
     StoreSet(AcceptRolesMiddleware, roles)
   );


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Doc| No

****

## Description
Small clean up on the passport tutorial roles snippet:

* Incorrect import
* Switch to use non deprecated function

## Usage example

N/A

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [x] Documentation
