### PR TITLE
feat(common): Add middlewares options to the Server configuration.

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -171,6 +171,72 @@ It is also possible to split the configuration by using the @@Module@@:
 
 List of glob pattern to scan directories which contains [Services](/docs/services.md), [Middlewares](/docs/middlewares.md) or [Converters](/docs/converters.md).
 
+### middlewares <Badge text="v6.28.0+" />
+
+- type: `PlatformMiddlewareSettings[]`
+
+A middleware list (Express.js, Ts.ED, Koa, etc...) must be loaded on the `$beforeRoutesInit` hook or on the specified hook. 
+In addition, it's also possible to configure the environment for which the middleware should be loaded.
+
+Here is an example to load middlewares with the previous version (this example will be always available!):
+
+```typescript
+import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
+import {Env} from "@tsed/core";
+
+@Configuration({})
+export class Server {
+  $afterInit(){
+    this.app.use(helmet({contentSecurityPolicy: false}))
+  }
+  $beforeRoutesInit() {
+    if (this.env === Env.PROD) {
+      this.app.use(EnsureHttpsMiddleware);
+    }
+
+    this.app
+      .use(cors())
+      .use(cookieParser())
+      .use(compress({}))
+      .use(methodOverride())
+      .use(bodyParser.json())
+      .use(bodyParser.urlencoded({
+        extended: true
+      }))
+      .use(AuthTokenMiddleware);
+
+    return null;
+  }
+}
+```
+
+After v6.28.0, you can use the middlewares options as follows:
+
+```typescript
+import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
+
+@Configuration({
+  middlewares: [
+    {hook: '$afterInit', use: helmet({contentSecurityPolicy: false})},
+    {env: Env.PROD, use: EnsureHttpsMiddleware},
+    cors(),
+    cookieParser(),
+    compress({}),
+    methodOverride(),
+    bodyParser.json(),
+    bodyParser.urlencoded({
+      extended: true
+    }),
+    AuthTokenMiddleware
+  ]
+})
+export class Server {
+}
+```
+::: warning Order priority
+The middlewares added through `middlewares` options will always be registered after the middlewares registered through the hook methods!
+:::
+
 ### imports
 
 - type: `Type<any>[]`

--- a/docs/docs/middlewares.md
+++ b/docs/docs/middlewares.md
@@ -10,7 +10,7 @@ This method can use all parameters decorators as you could see with the [Control
 
 ## Configuration
 
-To begin, you must add the `middlewares` folder on the `componentsScan` attribute in your server settings as follow :
+To begin, you must add the `middlewares` folder on the `componentsScan` attribute in your server settings as follows:
 
 <<< @/docs/docs/snippets/middlewares/server-configuration.ts
 
@@ -38,6 +38,36 @@ Global middlewares are generally used to handle requests before or after control
 Then add your middleware on the Server by using the right hook:
 
 <<< @/docs/docs/snippets/middlewares/global-middleware-configuration.ts
+
+::: tip
+Since v6.28.0, it's also possible to register middlewares from `middlewares` options on @@Configuration@@ decorator.
+In addition, it's also possible to configure the environment for which the middleware should be loaded.
+
+```typescript
+import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
+
+@Configuration({
+  middlewares: [
+    {hook: '$afterInit', use: helmet({contentSecurityPolicy: false})},
+    {env: Env.PROD, use: EnsureHttpsMiddleware},
+    cors(),
+    cookieParser(),
+    compress({}),
+    methodOverride(),
+    bodyParser.json(),
+    bodyParser.urlencoded({
+      extended: true
+    }),
+    AuthTokenMiddleware
+  ]
+})
+export class Server {
+}
+```
+
+The middlewares added through `middlewares` options will always be registered after the middlewares registered through the hook methods!
+
+:::
 
 ## Endpoint middleware 
 

--- a/docs/getting-started/snippets/base/package.json
+++ b/docs/getting-started/snippets/base/package.json
@@ -67,6 +67,6 @@
     "supertest": "6.0.0",
     "ts-node": "9.0.0",
     "tslint": "6.1.3",
-    "typescript": "4.0.2"
+    "typescript": "4.2.3"
   }
 }

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,3 +1,72 @@
+#### v6.28.0
+
+- Add middlewares options to the Server configuration. 
+
+Provide a middleware list (Express.js, Ts.ED, Koa, etc...) which must be loaded on the `$beforeRoutesInit` hook or on the specified hook.
+In addition, it's also possible to configure the `environment` for which the middleware should be loaded.
+
+Here is an example to load middlewares with the previous version (this example will be always available!):
+
+```typescript
+import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
+import {Env} from "@tsed/core";
+
+@Configuration({})
+export class Server {
+  $afterInit(){
+    this.app.use(helmet({contentSecurityPolicy: false}))
+  }
+  $beforeRoutesInit() {
+    if (this.env === Env.PROD) {
+      this.app.use(EnsureHttpsMiddleware);
+    }
+
+    this.app
+      .use(cors())
+      .use(cookieParser())
+      .use(compress({}))
+      .use(methodOverride())
+      .use(bodyParser.json())
+      .use(bodyParser.urlencoded({
+        extended: true
+      }))
+      .use(AuthTokenMiddleware);
+
+    return null;
+  }
+}
+```
+
+After v6.28.0, you can use the middlewares options as alternative way to load middlewares:
+
+```typescript
+import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
+
+@Configuration({
+  middlewares: [
+    {hook: '$afterInit', use: helmet({contentSecurityPolicy: false})},
+    {env: Env.PROD, use: EnsureHttpsMiddleware},
+    cors(),
+    cookieParser(),
+    compress({}),
+    methodOverride(),
+    bodyParser.json(),
+    bodyParser.urlencoded({
+      extended: true
+    }),
+    AuthTokenMiddleware
+  ]
+})
+export class Server {
+}
+```
+
+::: warning Order priority
+The middlewares added through `middlewares` options will always be registered after the middlewares registered through the hook methods!
+:::
+
+---
+
 #### v6.26.0
 
 - Add new packages `@tsed/async-hook-context`. See our [documentation over AsyncHookContext](/docs/request-context.md#async-hook-context).

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "ts-node": "9.0.0",
     "tsconfig-paths": "3.9.0",
     "tslib": "2.0.1",
-    "typescript": "4.0.2",
+    "typescript": "4.2.3",
     "vue-analytics": "5.22.1",
     "vuepress": "1.8.0",
     "vuepress-theme-tsed": "3.6.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "homepage": "http://tsed.io/",
   "dependencies": {
-    "@tsed/logger": "^5.5.4",
+    "@tsed/logger": "^5.6.0",
     "ajv": "7.0.1",
     "consolidate": "0.16.0",
     "ejs": "^3.1.5",

--- a/packages/common/src/config/interfaces/index.ts
+++ b/packages/common/src/config/interfaces/index.ts
@@ -1,12 +1,15 @@
 import {Env, Type} from "@tsed/core";
 import Https from "https";
+import {ResponseFilterMethods} from "../../platform-response-filter/interfaces/ResponseFilterMethods";
 import {ConverterSettings} from "./ConverterSettings";
 import {EndpointDirectoriesSettings} from "./EndpointDirectoriesSettings";
 import {PlatformLoggerSettings} from "./PlatformLoggerSettings";
 import {PlatformMulterSettings} from "./PlatformMulterSettings";
 import {PlatformStaticsSettings} from "./PlatformStaticsSettings";
 import {PlatformViewsSettings} from "./PlatformViewsSettings";
-import {ResponseFilterMethods} from "../../platform-response-filter/interfaces/ResponseFilterMethods";
+
+export type PlatformMiddlewareLoadingOptions = {env?: Env; use: Function | Type<any>; hook?: string};
+export type PlatformMiddlewareSettings = Function | Type<any> | PlatformMiddlewareLoadingOptions;
 
 declare global {
   namespace TsED {
@@ -75,6 +78,10 @@ declare global {
        * Object configure Multer. See more on [Upload file](/tutorials/serve-static-files.md).
        */
       multer: PlatformMulterSettings;
+      /**
+       * Load middlewares on the $beforeRoutesInit hook (or on the specified hook event name).
+       */
+      middlewares: PlatformMiddlewareSettings[];
       /**
        * Object to configure Views engines with Consolidate. See more on [View engine](/docs/template-engine.md).
        */

--- a/packages/core/src/utils/proxyDelegation.ts
+++ b/packages/core/src/utils/proxyDelegation.ts
@@ -13,7 +13,7 @@ export type ProxyDelegationSetter<T = any> = (target: T, property: PropertyKey, 
 /**
  * @ignore
  */
-export type ProxyDelegationOwnKeys<T = any> = (target: T) => PropertyKey[];
+export type ProxyDelegationOwnKeys<T = any> = (target: T) => (string | symbol)[];
 /**
  * @ignore
  */
@@ -80,7 +80,7 @@ export function proxyDelegation<T extends object = any>(self: any, options: Prox
       return Reflect.defineProperty(target, p, attributes);
     },
 
-    ownKeys(target: any): PropertyKey[] {
+    ownKeys(target: any) {
       return Reflect.ownKeys(target).concat((ownKeys && ownKeys(target)) || []);
     },
     ...handlers

--- a/packages/passport/src/middlewares/PassportMiddleware.ts
+++ b/packages/passport/src/middlewares/PassportMiddleware.ts
@@ -57,7 +57,7 @@ export class PassportMiddleware {
 
       await new Promise((resolve, reject) => {
         middleware(request, response, (err: any) => {
-          err ? reject(err) : resolve();
+          err ? reject(err) : resolve(undefined);
         });
       });
     } catch (er) {

--- a/packages/platform-express/test/app/Server.ts
+++ b/packages/platform-express/test/app/Server.ts
@@ -25,7 +25,32 @@ export const rootDir = __dirname;
     extensions: {
       ejs: "ejs"
     }
-  }
+  },
+  middlewares: [
+    cookieParser(),
+    compress({}),
+    methodOverride(),
+    bodyParser.json(),
+    bodyParser.urlencoded({
+      extended: true
+    }),
+    session({
+      secret: "keyboard cat", // change secret key
+      resave: false,
+      saveUninitialized: true,
+      cookie: {
+        secure: false // set true if HTTPS is enabled
+      }
+    }),
+    {
+      hook: "$afterInit", use: (req: any, res: any, next: any) => {
+        next();
+      }
+    },
+    (req: any, res: any, next: any) => {
+      setTimeout(next, 100);
+    }
+  ]
 })
 export class Server {
   @Inject()
@@ -38,31 +63,5 @@ export class Server {
     this.app.getApp().set("query parser", (queryString: string) => {
       return parse(queryString);
     });
-  }
-
-  $beforeRoutesInit() {
-    this.app
-      .use(cookieParser())
-      .use(compress({}))
-      .use(methodOverride())
-      .use(bodyParser.json())
-      .use(
-        bodyParser.urlencoded({
-          extended: true
-        })
-      )
-      .use(
-        session({
-          secret: "keyboard cat", // change secret key
-          resave: false,
-          saveUninitialized: true,
-          cookie: {
-            secure: false // set true if HTTPS is enabled
-          }
-        })
-      )
-      .use((req: any, res: any, next: any) => {
-        setTimeout(next, 100);
-      });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18896,10 +18896,10 @@ typeorm@^0.2.26:
     yargonaut "^1.1.2"
     yargs "^16.0.3"
 
-typescript@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+typescript@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,17 +2389,6 @@
     streamroller "^1.0.3"
     tslib "2.0.3"
 
-"@tsed/logger@^5.5.4":
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-5.5.4.tgz#19ae5ea0358c9ca81c8ab24470721678c81cafb2"
-  integrity sha512-yQyFcws3TQsDpAwS2h4sLbxc0gEKgngdp8PI7HQywwhhr/IVix3yhl7A5RBn6fwunW6vDhjUi8Z6hzwvyIZA6g==
-  dependencies:
-    colors "^1.3.3"
-    date-format "^3.0.0"
-    semver "^7.3.2"
-    streamroller "^1.0.3"
-    tslib "2.0.3"
-
 "@tsed/markdown-it-symbols@2.15.0":
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@tsed/markdown-it-symbols/-/markdown-it-symbols-2.15.0.tgz#0e1a1f0b72d6ae5e655228913befe617a5407dad"


### PR DESCRIPTION
Provide a middleware list (Express.js, Ts.ED, Koa, etc...) which must be loaded on the `$beforeRoutesInit` hook or on the specified hook.
In addition, it's also possible to configure the `environment` for which the middleware should be loaded.

Here is an example to load middlewares with the previous version (this example will be always available!):

```typescript
import {Configuration, ProviderScope, ProviderType} from "@tsed/di";
import {Env} from "@tsed/core";

@Configuration({})
export class Server {
  $afterInit(){
    this.app.use(helmet({contentSecurityPolicy: false}))
  }
  $beforeRoutesInit() {
    if (this.env === Env.PROD) {
      this.app.use(EnsureHttpsMiddleware);
    }

    this.app
      .use(cors())
      .use(cookieParser())
      .use(compress({}))
      .use(methodOverride())
      .use(bodyParser.json())
      .use(bodyParser.urlencoded({
        extended: true
      }))
      .use(AuthTokenMiddleware);

    return null;
  }
}
```

After v6.28.0, you can use the middlewares options as alternative way to load middlewares:

```typescript
import {Configuration, ProviderScope, ProviderType} from "@tsed/di";

@Configuration({
  middlewares: [
    {hook: '$afterInit', use: helmet({contentSecurityPolicy: false})},
    {env: Env.PROD, use: EnsureHttpsMiddleware},
    cors(),
    cookieParser(),
    compress({}),
    methodOverride(),
    bodyParser.json(),
    bodyParser.urlencoded({
      extended: true
    }),
    AuthTokenMiddleware
  ]
})
export class Server {
}
```

::: warning Order priority
The middlewares added through `middlewares` options will always be registered after the middlewares registered through the hook methods!
:::

## Information

Type | Breaking change
---|---
Feature/Fix/Doc/Chore | Yes/No

****

## Description
A few sentences describing the overall goals of the pull request's commits.

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
