### PR TITLE
fix(di): Update InterceptorContext interface

### DIFF
--- a/packages/di/src/decorators/intercept.ts
+++ b/packages/di/src/decorators/intercept.ts
@@ -9,7 +9,7 @@ import {IInjectableProperties, InjectablePropertyType, InterceptorMethods} from 
  * @param options
  * @decorator
  */
-export function Intercept<T extends InterceptorMethods>(interceptor: Type<T>, options?: any): Function {
+export function Intercept<T extends InterceptorMethods>(interceptor: Type<T>, options?: any): MethodDecorator {
   return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
     Store.from(target).merge(INJECTABLE_PROP, {
       [propertyKey]: {

--- a/packages/di/src/interfaces/InterceptorContext.ts
+++ b/packages/di/src/interfaces/InterceptorContext.ts
@@ -1,11 +1,13 @@
+import {Type} from "@tsed/core";
+
 export interface InterceptorNext {
   <T>(err?: Error): T;
 }
 
-export interface InterceptorContext<T> {
-  target: T;
+export interface InterceptorContext<Klass = Type, Opts = any> {
+  target: Klass;
   propertyKey: string;
   args: any[];
   next: InterceptorNext;
-  options?: any;
+  options?: Opts;
 }

--- a/packages/di/src/interfaces/InterceptorMethods.ts
+++ b/packages/di/src/interfaces/InterceptorMethods.ts
@@ -1,5 +1,5 @@
 import {InterceptorContext, InterceptorNext} from "./InterceptorContext";
 
 export interface InterceptorMethods {
-  intercept?(context: InterceptorContext<any>, next?: InterceptorNext): any;
+  intercept?(context: InterceptorContext, next?: InterceptorNext): any;
 }


### PR DESCRIPTION
Now InterceptorContext accept a second generic type.

```typescript
export interface InterceptorContext<Klass = Type, Opts = any> {
  target: Klass;
  propertyKey: string;
  args: unknown[];
  next: InterceptorNext;
  options?: Opts;
}
```
