### PR TITLE
fix(json-mapper): Fix serialization issue with CoreMongooseArray

### DIFF
--- a/packages/json-mapper/src/utils/serialize.spec.ts
+++ b/packages/json-mapper/src/utils/serialize.spec.ts
@@ -35,6 +35,12 @@ describe("serialize()", () => {
       expect(serialize([""])).to.deep.eq([""]);
       expect(serialize(["1"])).to.deep.equal(["1"]);
       expect(serialize([1])).to.deep.equal([1]);
+
+      class ArrayLike extends Array {}
+      const arrayLike = new ArrayLike();
+      arrayLike.push(1);
+
+      expect(serialize(arrayLike)).to.deep.equal([1]);
     });
   });
   describe("Map<primitive>", () => {

--- a/packages/json-mapper/src/utils/serialize.ts
+++ b/packages/json-mapper/src/utils/serialize.ts
@@ -1,4 +1,16 @@
-import {classOf, isClass, isCollection, isEmpty, isFunction, isNil, isPlainObject, MetadataTypes, objectKeys, Type} from "@tsed/core";
+import {
+  classOf,
+  isArray,
+  isClass,
+  isCollection,
+  isEmpty,
+  isFunction,
+  isNil,
+  isPlainObject,
+  MetadataTypes,
+  objectKeys,
+  Type
+} from "@tsed/core";
 import {alterIgnore, getPropertiesStores, JsonEntityStore, JsonHookContext, JsonSchema} from "@tsed/schema";
 import "../components";
 import {JsonMapperContext} from "../domain/JsonMapperContext";
@@ -133,6 +145,11 @@ export function serialize(obj: any, {type, collectionType, groups = false, ...op
     const jsonMapper = types.get(type)!;
 
     return jsonMapper.serialize(obj, context);
+  }
+
+  if (isArray(obj)) {
+    // Serialize Array class like
+    return types.get(Array)?.serialize(obj, context);
   }
 
   return !isPlainObject(type) ? classToPlainObject(obj, options) : toObject(obj, options);

--- a/packages/mongoose/test/helpers/models/User.ts
+++ b/packages/mongoose/test/helpers/models/User.ts
@@ -79,7 +79,6 @@ export class TestProfile extends BaseModel {
   user: Ref<TestUser>;
 }
 
-
 @Model({ schemaOptions: { timestamps: true } })
 export class SelfUser {
 
@@ -88,4 +87,22 @@ export class SelfUser {
 
   @Ref(() => SelfUser)
   createdBy: Ref<SelfUser>;
+}
+
+@Model({name: "role", schemaOptions: {timestamps: {createdAt: "created", updatedAt: "updated"}}})
+export class TestRole extends BaseModel {
+  @Property()
+  name: string;
+
+  @Property()
+  description: string;
+}
+
+@Model({name: "usernew", schemaOptions: {timestamps: {createdAt: "created", updatedAt: "updated"}}})
+export class TestUserNew extends BaseModel {
+  @Property()
+  name: string;
+
+  @Ref(TestRole)
+  roles: Ref<TestRole>[];
 }


### PR DESCRIPTION
Mongoose wrap array to a CoreMongooseArray which isn't recognized by the json-mapper. To solve it, json-mapper test also the type of the object and infer the type as an ArrayLike.

Closes: #1290
