### PR TITLE
fix(typeorm): Support TypeORM ConnectionOptions without name property

### DIFF
--- a/packages/typeorm/src/TypeORMModule.ts
+++ b/packages/typeorm/src/TypeORMModule.ts
@@ -3,14 +3,14 @@ import {ConnectionOptions, ContainedType, getCustomRepository, useContainer} fro
 import {TypeORMService} from "./services/TypeORMService";
 
 export class TypeORMModule implements OnDestroy {
-  private settings: {[key: string]: ConnectionOptions};
+  private settings: ConnectionOptions[];
 
   constructor(configuration: Configuration, private typeORMService: TypeORMService) {
-    this.settings = configuration.get<{[key: string]: ConnectionOptions}>("typeorm") || {};
+    this.settings = configuration.get<ConnectionOptions[]>("typeorm") || [];
   }
 
   async init(): Promise<any> {
-    const promises = Object.keys(this.settings).map((key) => this.typeORMService.createConnection(key, this.settings[key]));
+    const promises = this.settings.map((opts) => this.typeORMService.createConnection(opts));
 
     return Promise.all(promises);
   }

--- a/packages/typeorm/src/TypeORMModule.ts
+++ b/packages/typeorm/src/TypeORMModule.ts
@@ -6,7 +6,7 @@ export class TypeORMModule implements OnDestroy {
   private settings: ConnectionOptions[];
 
   constructor(configuration: Configuration, private typeORMService: TypeORMService) {
-    this.settings = configuration.get<ConnectionOptions[]>("typeorm") || [];
+    this.settings = configuration.get<ConnectionOptions[]>("typeorm", []);
   }
 
   async init(): Promise<any> {

--- a/packages/typeorm/src/services/TypeORMService.spec.ts
+++ b/packages/typeorm/src/services/TypeORMService.spec.ts
@@ -52,13 +52,13 @@ describe("TypeORMService", () => {
       } as any;
 
       // WHEN
-      const result1 = await service.createConnection("key", {config: "config"} as any);
-      const result2 = await service.createConnection("key", {config: "config"} as any);
+      const result1 = await service.createConnection({name: "mydb", config: "config"} as any);
+      const result2 = await service.createConnection({name: "mydb", config: "config"} as any);
 
       // THEN
       expect(result1).to.deep.eq(connection);
       expect(result2).to.deep.eq(connection);
-      expect(connectionManager.create).to.have.been.calledOnce.and.calledWithExactly({config: "config", name: "key"});
+      expect(connectionManager.create).to.have.been.calledOnce.and.calledWithExactly({name: "mydb", config: "config"});
 
       // WHEN close
       await service.closeConnections();

--- a/packages/typeorm/src/services/TypeORMService.spec.ts
+++ b/packages/typeorm/src/services/TypeORMService.spec.ts
@@ -18,24 +18,45 @@ describe("TypeORMService", () => {
 
     it("should create connection and close connection", async () => {
       // GIVEN
-      const connection: any = {
+      const defaultConnection: any = {
         isConnected: true,
         connect: Sinon.stub().resolves(),
         close: Sinon.stub()
       };
-      let called = false;
-      const connectionManager = {
-        create: Sinon.stub().returns(connection),
-        has: Sinon.stub().callsFake((id) => {
-          if (called) {
-            return true;
-          }
-          called = true;
+      const customConnection: any = {
+        isConnected: true,
+        connect: Sinon.stub().resolves(),
+        close: Sinon.stub()
+      };
 
-          return false;
+      let isDefaultConnectionCreated = false;
+      let isCustomConnectionCreated = false;
+
+      const connectionManager = {
+        create: Sinon.stub().callsFake((opts: TypeORM.ConnectionOptions) => {
+          if (opts.name == null || opts.name === "default") {
+            isDefaultConnectionCreated = true;
+            return defaultConnection;
+          } else {
+            isCustomConnectionCreated = true;
+            return customConnection;
+          }
         }),
-        get: Sinon.stub().returns(connection),
-        connections: [connection]
+        has: Sinon.stub().callsFake((name) => {
+          if (name == null || name === "default") {
+            return isDefaultConnectionCreated;
+          } else {
+            return isCustomConnectionCreated;
+          }
+        }),
+        get: Sinon.stub().callsFake((name) => {
+          if (name == null || name === "default") {
+            return defaultConnection;
+          } else {
+            return customConnection;
+          }
+        }),
+        connections: [defaultConnection, customConnection]
       };
 
       // @ts-ignore
@@ -54,17 +75,67 @@ describe("TypeORMService", () => {
       // WHEN
       const result1 = await service.createConnection({name: "mydb", config: "config"} as any);
       const result2 = await service.createConnection({name: "mydb", config: "config"} as any);
+      const result3 = await service.createConnection({config: "config"} as any);
+      const result4 = await service.createConnection({config: "config"} as any);
 
-      // THEN
-      expect(result1).to.deep.eq(connection);
-      expect(result2).to.deep.eq(connection);
-      expect(connectionManager.create).to.have.been.calledOnce.and.calledWithExactly({name: "mydb", config: "config"});
+      // // THEN
+      expect(result1).to.deep.eq(customConnection);
+      expect(result2).to.deep.eq(customConnection);
+      expect(result3).to.deep.eq(defaultConnection);
+      expect(result4).to.deep.eq(defaultConnection);
+      expect(connectionManager.create).to.have.been.calledTwice;
+      expect(connectionManager.create).calledWithExactly({name: "mydb", config: "config"});
+      expect(connectionManager.create).calledWithExactly({name: undefined, config: "config"});
 
       // WHEN close
       await service.closeConnections();
 
       // THEN
-      expect(connection.close).to.have.been.calledWithExactly();
+      expect(defaultConnection.close).to.have.been.calledWithExactly();
+      expect(customConnection.close).to.have.been.calledWithExactly();
+    });
+  });
+
+  describe("get()", () => {
+    before(() => {
+      Sinon.stub(TypeORM, "getConnectionManager");
+    });
+
+    after(() => {
+      PlatformTest.reset();
+      // @ts-ignore
+      TypeORM.getConnectionManager.restore();
+    });
+
+    it("should return corresponded connections", async () => {
+      // GIVEN
+      const defaultConnection = {name: "default"};
+      const customConnection = {name: "custom"};
+      const connectionManager = {
+        get: Sinon.stub().callsFake((name) => {
+          if (name == null || name === "default") {
+            return defaultConnection;
+          } else if (name === "custom") {
+            return customConnection;
+          }
+          return null;
+        })
+      };
+
+      // @ts-ignore
+      TypeORM.getConnectionManager.returns(connectionManager);
+
+      const service = new TypeORMService();
+
+      // WHEN
+      const result1 = service.get();
+      const result2 = service.get("default");
+      const result3 = service.get("custom");
+
+      // THEN
+      expect(result1).to.deep.eq(defaultConnection);
+      expect(result2).to.deep.eq(defaultConnection);
+      expect(result3).to.deep.eq(customConnection);
     });
   });
 });

--- a/packages/typeorm/src/services/TypeORMService.spec.ts
+++ b/packages/typeorm/src/services/TypeORMService.spec.ts
@@ -85,7 +85,7 @@ describe("TypeORMService", () => {
       expect(result4).to.deep.eq(defaultConnection);
       expect(connectionManager.create).to.have.been.calledTwice;
       expect(connectionManager.create).calledWithExactly({name: "mydb", config: "config"});
-      expect(connectionManager.create).calledWithExactly({name: undefined, config: "config"});
+      expect(connectionManager.create).calledWithExactly({name: "default", config: "config"});
 
       // WHEN close
       await service.closeConnections();

--- a/packages/typeorm/src/services/TypeORMService.ts
+++ b/packages/typeorm/src/services/TypeORMService.ts
@@ -19,13 +19,13 @@ export class TypeORMService {
    * @returns {Promise<"typeorm".Connection>}
    */
   async createConnection(connectionOptions: ConnectionOptions): Promise<any> {
-    const name = connectionOptions.name ?? "default";
+    const name = connectionOptions.name;
 
     if (this.has(name)) {
       return this.get(name);
     }
 
-    this.injector.logger.info(`Create connection with typeorm to database: ${name}`);
+    this.injector.logger.info(`Create connection with typeorm to database: ${name ?? "default"}`);
     this.injector.logger.debug(`options: ${JSON.stringify(connectionOptions)}`);
 
     try {

--- a/packages/typeorm/src/services/TypeORMService.ts
+++ b/packages/typeorm/src/services/TypeORMService.ts
@@ -56,7 +56,7 @@ export class TypeORMService {
    * @param {string} id
    * @returns {boolean}
    */
-  has(id: string = "default"): boolean {
+  has(id: string): boolean {
     return this.connectionManager.has(id);
   }
 

--- a/packages/typeorm/src/services/TypeORMService.ts
+++ b/packages/typeorm/src/services/TypeORMService.ts
@@ -1,4 +1,5 @@
 import {Inject, InjectorService, Service} from "@tsed/common";
+import {getValue} from "@tsed/core";
 import {Connection, ConnectionManager, ConnectionOptions, getConnectionManager} from "typeorm";
 import {createConnection} from "../utils/createConnection";
 
@@ -19,19 +20,19 @@ export class TypeORMService {
    * @returns {Promise<"typeorm".Connection>}
    */
   async createConnection(connectionOptions: ConnectionOptions): Promise<any> {
-    const name = connectionOptions.name;
+    const name = getValue<string>(connectionOptions, "name", "default");
 
     if (this.has(name)) {
       return this.get(name);
     }
 
-    this.injector.logger.info(`Create connection with typeorm to database: ${name ?? "default"}`);
+    this.injector.logger.info(`Create connection with typeorm to database: ${name}`);
     this.injector.logger.debug(`options: ${JSON.stringify(connectionOptions)}`);
 
     try {
       const connection = await createConnection({...connectionOptions, name});
 
-      this.injector.logger.info(`Connected with typeorm to database: ${connection.name}`);
+      this.injector.logger.info(`Connected with typeorm to database: ${name}`);
 
       return connection;
     } catch (err) {

--- a/packages/typeorm/src/services/TypeORMService.ts
+++ b/packages/typeorm/src/services/TypeORMService.ts
@@ -18,20 +18,20 @@ export class TypeORMService {
    *
    * @returns {Promise<"typeorm".Connection>}
    */
-  async createConnection(id: string = "default", settings: ConnectionOptions): Promise<any> {
-    const key = settings.name || id;
+  async createConnection(connectionOptions: ConnectionOptions): Promise<any> {
+    const name = connectionOptions.name ?? "default";
 
-    if (key && this.has(key)) {
-      return this.get(key);
+    if (this.has(name)) {
+      return this.get(name);
     }
 
-    this.injector.logger.info(`Create connection with typeorm to database: ${key}`);
-    this.injector.logger.debug(`options: ${JSON.stringify(settings)}`);
+    this.injector.logger.info(`Create connection with typeorm to database: ${name}`);
+    this.injector.logger.debug(`options: ${JSON.stringify(connectionOptions)}`);
 
     try {
-      const connection = await createConnection({...settings, name: key});
+      const connection = await createConnection({...connectionOptions, name});
 
-      this.injector.logger.info(`Connected with typeorm to database: ${key}`);
+      this.injector.logger.info(`Connected with typeorm to database: ${connection.name}`);
 
       return connection;
     } catch (err) {

--- a/packages/typeorm/src/services/TypeORMService.ts
+++ b/packages/typeorm/src/services/TypeORMService.ts
@@ -56,7 +56,7 @@ export class TypeORMService {
    * @param {string} id
    * @returns {boolean}
    */
-  has(id: string): boolean {
+  has(id: string = "default"): boolean {
     return this.connectionManager.has(id);
   }
 

--- a/packages/typeorm/src/utils/createConnection.spec.ts
+++ b/packages/typeorm/src/utils/createConnection.spec.ts
@@ -1,0 +1,72 @@
+import {expect} from "chai";
+import Sinon from "sinon";
+import * as TypeORM from "typeorm";
+
+import {createConnection} from "./createConnection";
+
+describe("createConnection", () => {
+  before(() => {
+    Sinon.stub(TypeORM, "getConnectionManager");
+  });
+
+  after(() => {
+    // @ts-ignore
+    TypeORM.getConnectionManager.restore();
+  });
+
+  it("should create connection and return cache", async () => {
+    // GIVEN
+    const defaultConnection: any = {
+      isConnected: true,
+      connect: Sinon.stub().resolves()
+    };
+    const customConnection: any = {
+      isConnected: true,
+      connect: Sinon.stub().resolves()
+    };
+
+    let isDefaultConnectionCreated = false;
+    let isCustomConnectionCreated = false;
+
+    const connectionManager = {
+      create: Sinon.stub().callsFake((opts: TypeORM.ConnectionOptions) => {
+        if (opts.name == null || opts.name === "default") {
+          isDefaultConnectionCreated = true;
+          return defaultConnection;
+        } else {
+          isCustomConnectionCreated = true;
+          return customConnection;
+        }
+      }),
+      has: Sinon.stub().callsFake((name) => {
+        if (name == null || name === "default") {
+          return isDefaultConnectionCreated;
+        } else {
+          return isCustomConnectionCreated;
+        }
+      }),
+      get: Sinon.stub().callsFake((name) => {
+        if (name == null || name === "default") {
+          return defaultConnection;
+        } else {
+          return customConnection;
+        }
+      }),
+      connections: [defaultConnection, customConnection]
+    };
+
+    // @ts-ignore
+    TypeORM.getConnectionManager.returns(connectionManager);
+
+    // WHEN
+    const result1 = await createConnection({name: "mydb", type: "mysql"});
+    const result2 = await createConnection({name: "mydb", type: "mysql"});
+
+    // THEN
+    expect(result1).to.deep.eq(customConnection);
+    expect(result2).to.deep.eq(customConnection);
+    expect(connectionManager.create).to.have.been.calledOnce.and.calledWithExactly({name: "mydb", type: "mysql"});
+    expect(defaultConnection.connect).to.have.not.been.called;
+    expect(customConnection.connect).to.have.been.calledOnce;
+  });
+});

--- a/packages/typeorm/src/utils/createConnection.ts
+++ b/packages/typeorm/src/utils/createConnection.ts
@@ -4,7 +4,7 @@ const connections = new Map();
 
 export async function createConnection(connectionOptions: ConnectionOptions) {
   const connectionManager = getConnectionManager();
-  const name = connectionOptions.name!;
+  const name = connectionOptions.name ?? "default";
 
   if (!connections.has(name)) {
     const connection = connectionManager.create(connectionOptions!);

--- a/packages/typeorm/src/utils/createConnection.ts
+++ b/packages/typeorm/src/utils/createConnection.ts
@@ -1,8 +1,9 @@
-import {ConnectionOptions, getConnectionManager} from "typeorm";
+import {getValue} from "@tsed/core";
+import {Connection, ConnectionOptions, getConnectionManager} from "typeorm";
 
-export async function createConnection(connectionOptions: ConnectionOptions) {
+export async function createConnection(connectionOptions: ConnectionOptions): Promise<Connection> {
   const connectionManager = getConnectionManager();
-  const name = connectionOptions.name ?? "default";
+  const name = getValue<string>(connectionOptions, "name", "default");
 
   if (!connectionManager.has(name)) {
     const connection = connectionManager.create(connectionOptions!);

--- a/packages/typeorm/src/utils/createConnection.ts
+++ b/packages/typeorm/src/utils/createConnection.ts
@@ -1,17 +1,13 @@
 import {ConnectionOptions, getConnectionManager} from "typeorm";
 
-const connections = new Map();
-
 export async function createConnection(connectionOptions: ConnectionOptions) {
   const connectionManager = getConnectionManager();
   const name = connectionOptions.name ?? "default";
 
-  if (!connections.has(name)) {
+  if (!connectionManager.has(name)) {
     const connection = connectionManager.create(connectionOptions!);
-    connections.set(name, connection.connect());
+    await connection.connect();
   }
-
-  await connections.get(name);
 
   const connection = connectionManager.get(name);
 

--- a/packages/typeorm/src/utils/createConnection.ts
+++ b/packages/typeorm/src/utils/createConnection.ts
@@ -12,9 +12,5 @@ export async function createConnection(connectionOptions: ConnectionOptions): Pr
 
   const connection = connectionManager.get(name);
 
-  // Add hook to close connection when server is killed
-  // @ts-ignore
-  connection.$onDestroy = connection.$onDestroy || (() => connection.isConnected && connection.close());
-
   return connection;
 }

--- a/packages/typeorm/test/integration.spec.ts
+++ b/packages/typeorm/test/integration.spec.ts
@@ -13,7 +13,6 @@ describe("TypeORM integration", () => {
     const bstrp = PlatformTest.bootstrap(Server, {
       typeorm: [
         {
-          name: "default",
           type: "mongodb",
           url,
           entities: [User],


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

****

## Description
- refs #1332 
- This PR will fix only the first point
    - https://github.com/TypedProject/tsed/issues/1332#issuecomment-813404171

## Todos

- [x] Tests
- [x] Coverage
- [ ] Example
- [ ] Documentation
