### PR TITLE
fix: use seconds instead of expires for cache-control max-age value

### DIFF
--- a/packages/common/src/platform-cache/interceptors/PlatformCacheInterceptor.ts
+++ b/packages/common/src/platform-cache/interceptors/PlatformCacheInterceptor.ts
@@ -119,7 +119,7 @@ export class PlatformCacheInterceptor implements InterceptorMethods {
     const calculatedTtl = this.cache.ttl(result, ttl);
     const expires = calculatedTtl + Date.now() / 1000;
     $ctx.response.setHeaders({
-      "cache-control": `max-age=${expires.toFixed(0)}`
+      "cache-control": `max-age=${calculatedTtl}`
     });
 
     // cache final response with his headers and body
@@ -146,7 +146,7 @@ export class PlatformCacheInterceptor implements InterceptorMethods {
   }
 
   protected sendResponse(cachedObject: PlatformCachedObject, $ctx: PlatformContext) {
-    const {headers, expires} = cachedObject;
+    const {headers, ttl} = cachedObject;
     const {request, response} = $ctx;
 
     const requestEtag = request.get("if-none-match");
@@ -163,7 +163,7 @@ export class PlatformCacheInterceptor implements InterceptorMethods {
       .setHeaders({
         ...headers,
         "x-cached": "true",
-        "cache-control": `max-age=${(expires - Date.now()).toFixed(0)}`
+        "cache-control": `max-age=${ttl}`
       })
       .body(data);
 

--- a/packages/platform-test-utils/src/tests/testCache.ts
+++ b/packages/platform-test-utils/src/tests/testCache.ts
@@ -104,11 +104,11 @@ export function testCache(options: PlatformTestOptions) {
         const response2 = await request.get("/rest/caches/scenario-1").expect(200);
 
         expect(response.text).to.contains("hello world");
-        expect(response.headers["cache-control"]).to.includes("max-age");
+        expect(response.headers["cache-control"]).to.match(/max-age=300/);
         expect(response.headers["x-cached"]).to.equal(undefined);
 
         expect(response2.text).to.contains("hello world");
-        expect(response2.headers["cache-control"]).to.includes("max-age");
+        expect(response2.headers["cache-control"]).to.match(/max-age=300/);
         expect(response2.headers["x-cached"]).to.equal("true");
         expect(response2.headers["etag"]).to.equal(response.headers["etag"]);
       });
@@ -130,11 +130,11 @@ export function testCache(options: PlatformTestOptions) {
         const response2 = await request.get("/rest/caches/scenario-1").set("cache-control", "no-cache").expect(200);
 
         expect(response.text).to.contains("hello world");
-        expect(response.headers["cache-control"]).to.includes("max-age");
+        expect(response.headers["cache-control"]).to.match(/max-age=300/);
         expect(response.headers["x-cached"]).to.equal(undefined);
 
         expect(response2.text).to.contains("hello world");
-        expect(response2.headers["cache-control"]).to.includes("max-age");
+        expect(response2.headers["cache-control"]).to.match(/max-age=300/);
         expect(response2.headers["x-cached"]).to.equal("true");
         expect(response2.headers["etag"]).to.equal(response.headers["etag"]);
       });
@@ -145,11 +145,11 @@ export function testCache(options: PlatformTestOptions) {
         const response2 = await request.get("/rest/caches/scenario-2").expect(200);
 
         expect(response.body).to.deep.equal({info: "hello child"});
-        expect(response.headers["cache-control"]).to.includes("max-age");
+        expect(response.headers["cache-control"]).to.match(/max-age=400/);
         expect(response.headers["x-cached"]).to.equal(undefined);
 
         expect(response2.body).to.deep.equal({info: "hello child"});
-        expect(response2.headers["cache-control"]).to.includes("max-age");
+        expect(response2.headers["cache-control"]).to.match(/max-age=400/);
         expect(response2.headers["x-cached"]).to.equal("true");
         expect(response2.headers["etag"]).to.equal(response.headers["etag"]);
       });


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

****

## Description

The `max-age` value of the `cache-control` header should be a relative value to the request's time not an absolute timestamp.
Ie. to cache something for 30 seconds should have `cache-control: max-age=30`

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#expiration
https://www.keycdn.com/blog/http-cache-headers#:~:text=downloaded%20every%20time.-,max%2Dage,for%20the%20next%2090%20seconds.

## Usage example

Nothing changes in the usage.

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
