### PR TITLE
fix(swagger): Fix oauth2 redirect

### DIFF
--- a/packages/swagger/views/index.ejs
+++ b/packages/swagger/views/index.ejs
@@ -107,6 +107,7 @@
         SwaggerUIBundle.plugins.DownloadUrl
       ],
       layout: "StandaloneLayout",
+      oauth2RedirectUrl: currentUrl.replace('swagger.json', 'oauth2-redirect.html'),
       validatorUrl: origin.match('0.0.0.0') || origin.match('localhost') ? null : undefined
     }, initialOptions),
     /**


### PR DESCRIPTION
## Information
If swagger ui isn't exposed to / the redirect uri query param should be correctly after this fix.

Type | Breaking change
---|---
Fix | No

****
