### PR TITLE
feat(schema): Support enum and jsonSchema builder given to GenericOf and Returns.Of

### DIFF
--- a/packages/schema/src/decorators/generics/genericOf.spec.ts
+++ b/packages/schema/src/decorators/generics/genericOf.spec.ts
@@ -1,4 +1,4 @@
-import {CollectionOf, getJsonSchema, Property} from "@tsed/schema";
+import {CollectionOf, getJsonSchema, Property, string} from "@tsed/schema";
 import {expect} from "chai";
 import {GenericOf} from "./genericOf";
 import {Generics} from "./generics";
@@ -160,6 +160,82 @@ describe("@GenericOf", () => {
             },
             totalCount: {
               type: "number"
+            }
+          },
+          type: "object"
+        }
+      },
+      type: "object"
+    });
+  });
+  it("should generate Generic with an enum", () => {
+    @Generics("T")
+    class Submission<T> {
+      @Property()
+      _id: string;
+
+      @Property("T")
+      data: T;
+    }
+
+    enum MyEnum {
+      READ = "read",
+      WRITE = "write"
+    }
+
+    class Content {
+      @GenericOf(MyEnum)
+      submission: Submission<MyEnum>;
+    }
+
+    expect(getJsonSchema(Content)).to.deep.eq({
+      properties: {
+        submission: {
+          properties: {
+            _id: {
+              type: "string"
+            },
+            data: {
+              type: "string",
+              enum: ["read", "write"]
+            }
+          },
+          type: "object"
+        }
+      },
+      type: "object"
+    });
+  });
+  it("should generate Generic with raw json schema", () => {
+    @Generics("T")
+    class Submission<T> {
+      @Property()
+      _id: string;
+
+      @Property("T")
+      data: T;
+    }
+
+    enum MyEnum {
+      READ = "read",
+      WRITE = "write"
+    }
+
+    class Content {
+      @GenericOf(string().enum(["read", "write"]))
+      submission: Submission<MyEnum>;
+    }
+
+    expect(getJsonSchema(Content)).to.deep.eq({
+      properties: {
+        submission: {
+          properties: {
+            _id: {
+              type: "string"
+            },
+            data: {
+              type: "string",
+              enum: ["read", "write"]
             }
           },
           type: "object"

--- a/packages/schema/src/decorators/generics/genericOf.ts
+++ b/packages/schema/src/decorators/generics/genericOf.ts
@@ -1,13 +1,23 @@
-import {Type} from "@tsed/core";
+import {isObject, Type} from "@tsed/core";
 import {JsonEntityStore} from "../../domain/JsonEntityStore";
+import {string} from "../../utils/from";
+import {GenericValue} from "../../utils/generics";
+
+/**
+ * @ignore
+ */
+function isEnum(type: any) {
+  return isObject(type) && !("toJSON" in type);
+}
 
 export interface GenericOfChainedDecorators {
   (...args: any): any;
+
   /**
    * Declare a nested generic models
    * @param generics
    */
-  Nested(...generics: (Type<any> | any)[]): this;
+  Nested(...generics: GenericValue[]): this;
 }
 
 /**
@@ -76,8 +86,15 @@ export interface GenericOfChainedDecorators {
  * @input
  * @generics
  */
-export function GenericOf(...generics: Type<any>[]): GenericOfChainedDecorators {
-  const nestedGenerics: Type<any>[][] = [generics];
+export function GenericOf(...generics: GenericValue[]): GenericOfChainedDecorators {
+  const nestedGenerics: GenericValue[][] = [
+    generics.map((type) => {
+      if (isEnum(type)) {
+        return string().enum(Object.values(type));
+      }
+      return type;
+    })
+  ];
 
   const decorator = (...args: any) => {
     const store = JsonEntityStore.from(...args);

--- a/packages/schema/src/decorators/operations/returns.spec.ts
+++ b/packages/schema/src/decorators/operations/returns.spec.ts
@@ -803,6 +803,189 @@ describe("@Returns", () => {
         ]
       });
     });
+    it("should declare an Generic of Model with enum (OS3)", async () => {
+      // WHEN
+      @Generics("T")
+      class Submission<T> {
+        @Property()
+        _id: string;
+
+        @Property("T")
+        data: T;
+      }
+
+      enum MyEnum {
+        READ = "read",
+        WRITE = "write"
+      }
+
+      class Controller {
+        @OperationPath("POST", "/")
+        @(Returns(200, Submission).Of(MyEnum).Description("description"))
+        async method(): Promise<Submission<MyEnum> | null> {
+          return null;
+        }
+      }
+
+      // THEN
+      const spec = getSpec(Controller, {specType: SpecTypes.OPENAPI});
+
+      expect(spec).to.deep.equal({
+        paths: {
+          "/": {
+            post: {
+              operationId: "controllerMethod",
+              parameters: [],
+              responses: {
+                "200": {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        properties: {
+                          _id: {
+                            type: "string"
+                          },
+                          data: {
+                            enum: ["read", "write"],
+                            type: "string"
+                          }
+                        },
+                        type: "object"
+                      }
+                    }
+                  },
+                  description: "description"
+                }
+              },
+              tags: ["Controller"]
+            }
+          }
+        },
+        tags: [
+          {
+            name: "Controller"
+          }
+        ]
+      });
+    });
+    it("should declare an Generic of Model with enum with pagination(OS3)", async () => {
+      // WHEN
+      @Generics("T")
+      class Pagination<T> {
+        @CollectionOf("T")
+        data: T[];
+
+        @Property()
+        totalCount: number;
+      }
+
+      @Generics("T")
+      class Submission<T> {
+        @Property()
+        _id: string;
+
+        @Property("T")
+        data: T;
+      }
+
+      enum MyEnum {
+        READ = "read",
+        WRITE = "write"
+      }
+
+      class Controller {
+        @OperationPath("POST", "/")
+        @(Returns(200, Pagination)
+          .Of(Submission)
+          .Nested(MyEnum)
+          .Description("description")
+          .Examples({
+            Example1: {
+              value: [
+                {
+                  totalCount: 0,
+                  data: [
+                    {
+                      _id: "id",
+                      data: {}
+                    }
+                  ]
+                }
+              ]
+            }
+          }))
+        async method(): Promise<Pagination<Submission<MyEnum>> | null> {
+          return null;
+        }
+      }
+
+      // THEN
+      const spec = getSpec(Controller, {specType: SpecTypes.OPENAPI});
+
+      expect(spec).to.deep.equal({
+        paths: {
+          "/": {
+            post: {
+              operationId: "controllerMethod",
+              parameters: [],
+              responses: {
+                "200": {
+                  content: {
+                    "application/json": {
+                      examples: {
+                        Example1: {
+                          value: [
+                            {
+                              data: [
+                                {
+                                  _id: "id",
+                                  data: {}
+                                }
+                              ],
+                              totalCount: 0
+                            }
+                          ]
+                        }
+                      },
+                      schema: {
+                        properties: {
+                          data: {
+                            items: {
+                              properties: {
+                                _id: {
+                                  type: "string"
+                                },
+                                data: {
+                                  enum: ["read", "write"],
+                                  type: "string"
+                                }
+                              },
+                              type: "object"
+                            },
+                            type: "array"
+                          },
+                          totalCount: {
+                            type: "number"
+                          }
+                        },
+                        type: "object"
+                      }
+                    }
+                  },
+                  description: "description"
+                }
+              },
+              tags: ["Controller"]
+            }
+          }
+        },
+        tags: [
+          {
+            name: "Controller"
+          }
+        ]
+      });
+    });
   });
   describe("Multiple contentType", () => {
     it("should manage multiple content and model", () => {

--- a/packages/schema/src/utils/generics.ts
+++ b/packages/schema/src/utils/generics.ts
@@ -1,9 +1,12 @@
 import {Type} from "@tsed/core";
+import {JsonSchema} from "../domain";
+
+export type GenericValue = Type<any> | JsonSchema | any;
 
 /**
  * @ignore
  */
-export type GenericsMap = Map<string, Type<any>>;
+export type GenericsMap = Map<string, GenericValue>;
 
 /**
  * @ignore
@@ -27,7 +30,7 @@ export interface GenericLabels {
  * @ignore
  */
 export interface NestedGenerics {
-  nestedGenerics: Type<any>[][];
+  nestedGenerics: GenericValue[][];
 
   [key: string]: any;
 }
@@ -44,7 +47,7 @@ export interface GenericsContext extends GenericTypes, GenericLabels, NestedGene
  * @param genericLabels
  * @param genericTypes
  */
-export function getGenericsMap(genericLabels: string[], genericTypes: Type<any>[]): GenericsMap {
+export function getGenericsMap(genericLabels: string[], genericTypes: GenericValue[]): GenericsMap {
   return genericLabels.reduce((map: Map<string, any>, item: string, index: number) => map.set(item, genericTypes[index]), new Map());
 }
 

--- a/packages/schema/src/utils/serializeJsonSchema.ts
+++ b/packages/schema/src/utils/serializeJsonSchema.ts
@@ -1,4 +1,4 @@
-import {classOf, cleanObject, deepExtends, isArray, isObject} from "@tsed/core";
+import {classOf, cleanObject, deepExtends, isArray, isClass, isObject} from "@tsed/core";
 import {mapAliasedProperties} from "../domain/JsonAliasMap";
 import {JsonLazyRef} from "../domain/JsonLazyRef";
 import {JsonSchema} from "../domain/JsonSchema";
@@ -204,24 +204,35 @@ export function serializeGenerics(obj: any, options: GenericsContext) {
 
   if (generics && obj.$ref) {
     if (generics.has(obj.$ref)) {
-      const model = {
-        class: generics.get(obj.$ref)
-      };
+      let type = generics.get(obj.$ref);
 
-      if (options.nestedGenerics.length === 0) {
-        return serializeClass(model, {
+      if (type.toJSON) {
+        return type.toJSON({
           ...options,
           generics: undefined
         });
       }
 
-      const store = getJsonEntityStore(model.class);
+      if (isClass(type)) {
+        const model = {
+          class: type
+        };
 
-      return serializeJsonSchema(store.schema, {
-        ...options,
-        ...popGenerics(options),
-        root: false
-      });
+        if (options.nestedGenerics.length === 0) {
+          return serializeClass(model, {
+            ...options,
+            generics: undefined
+          });
+        }
+
+        const store = getJsonEntityStore(model.class);
+
+        return serializeJsonSchema(store.schema, {
+          ...options,
+          ...popGenerics(options),
+          root: false
+        });
+      }
     }
   }
 


### PR DESCRIPTION

Example1:
```typescript
@Generics("T")
class Submission<T> {
  @Property()
   _id: string;

  @Property("T")
  data: T;
}

enum MyEnum {
  READ = "read",
  WRITE = "write"
}

class Content {
   @GenericOf(MyEnum)
   submission: Submission<MyEnum>;
}
```

Example2:
```typescript
@Generics("T")
class Submission<T> {
  @Property()
   _id: string;

  @Property("T")
  data: T;
}

enum MyEnum {
  READ = "read",
  WRITE = "write"
}

class Content {
  @GenericOf(string().enum(["read", "write"]))
    submission: Submission<MyEnum>;
}
```

Closes: #1347
