### PR TITLE
fix(schema): Add missing export for the ForwardGroups decorator

### DIFF
--- a/packages/schema/src/decorators/index.ts
+++ b/packages/schema/src/decorators/index.ts
@@ -40,6 +40,7 @@ export * from "./common/enum";
 export * from "./common/exclusiveMaximum";
 export * from "./common/exclusiveMinimum";
 export * from "./common/format";
+export * from "./common/forwardGroups";
 export * from "./common/groups";
 export * from "./common/pattern";
 export * from "./common/ignore";


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

****

## Description
Add missing export for the ForwardGroups decorator to schema.

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import { ForwardGroups } from "@tsed/schema";

```

## Todos

- [x] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
