### PR TITLE
fix(ajv): clone value before validate data

### DIFF
--- a/packages/ajv/src/services/AjvService.ts
+++ b/packages/ajv/src/services/AjvService.ts
@@ -1,4 +1,4 @@
-import {getValue, nameOf, prototypeOf, setValue, Type} from "@tsed/core";
+import {deepClone, getValue, nameOf, prototypeOf, setValue, Type} from "@tsed/core";
 import {Constant, Inject, Injectable} from "@tsed/di";
 import {getJsonSchema, JsonEntityStore, JsonSchema, JsonSchemaObject} from "@tsed/schema";
 import Ajv, {ErrorObject} from "ajv";
@@ -48,13 +48,14 @@ export class AjvService {
     schema = schema || getJsonSchema(type, {...additionalOptions, customKeys: true});
 
     if (schema) {
-      const valid = await this.ajv.validate(schema as any, value);
+      const localValue = deepClone(value);
+      const valid = await this.ajv.validate(schema as any, localValue);
       if (!valid) {
         throw this.mapErrors(this.ajv.errors || [], {
           type,
           collectionType,
           async: true,
-          value
+          value: localValue
         });
       }
     }

--- a/packages/json-mapper/src/utils/deserialize.spec.ts
+++ b/packages/json-mapper/src/utils/deserialize.spec.ts
@@ -424,6 +424,34 @@ describe("deserialize()", () => {
       expect(result).to.be.instanceOf(Product);
       expect(result.updated).to.be.instanceOf(Date);
     });
+    it("should transform object to class (with null values on props)", () => {
+      class NullModel {
+        @Property()
+        prop1: string;
+
+        @Property()
+        prop2: number;
+
+        @Property()
+        prop3: Date;
+      }
+
+      const result = deserialize(
+        {
+          prop1: null,
+          prop2: null,
+          prop3: null
+        },
+        {type: NullModel}
+      );
+
+      expect(result).to.be.instanceOf(NullModel);
+      expect(result).to.deep.equal({
+        prop1: null,
+        prop2: null,
+        prop3: null
+      });
+    });
   });
   describe("Array<Model>", () => {
     it("should transform object to class (additionalProperties = false)", () => {

--- a/packages/platform-test-utils/src/tests/testBodyParams.ts
+++ b/packages/platform-test-utils/src/tests/testBodyParams.ts
@@ -1,6 +1,6 @@
 import "@tsed/ajv";
 import {BodyParams, Controller, HeaderParams, PlatformTest, Post, RawBodyParams} from "@tsed/common";
-import {Required, Status} from "@tsed/schema";
+import {Required, Status, Property} from "@tsed/schema";
 import {expect} from "chai";
 import SuperTest from "supertest";
 import {PlatformTestOptions} from "../interfaces";
@@ -8,6 +8,17 @@ import {PlatformTestOptions} from "../interfaces";
 enum MyEnum {
   TITLE,
   AGE
+}
+
+class NullModel {
+  @Property()
+  prop1: string;
+
+  @Property()
+  prop2: number;
+
+  @Property()
+  prop3: Date;
 }
 
 @Controller("/body-params")
@@ -56,6 +67,11 @@ class TestBodyParamsCtrl {
   @Post("/scenario-7")
   testScenario7(@BodyParams("test") value: string): any {
     return {value};
+  }
+
+  @Post("/scenario-8")
+  testScenario8(@BodyParams() model: NullModel) {
+    return {model};
   }
 }
 
@@ -265,6 +281,24 @@ export function testBodyParams(options: PlatformTestOptions) {
 
       expect(response.body).to.deep.equal({
         value: null
+      });
+    });
+  });
+
+  describe("Scenario8: payload with props to null", () => {
+    it("should return value with null value", async () => {
+      const response = await request.post("/rest/body-params/scenario-8").send({
+        prop1: null,
+        prop2: null,
+        prop3: null
+      });
+
+      expect(response.body).to.deep.equal({
+        model: {
+          prop1: null,
+          prop2: null,
+          prop3: null
+        }
       });
     });
   });


### PR DESCRIPTION
Since Ajv touch value in validated data, we need to clone deep the value before validate it.
