### PR TITLE
Removed duplicate OIDC tutorial link

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -106,7 +106,7 @@ Features | Express.js  | Koa.js
 [Swagger](/tutorials/swagger.html) | <img src="../assets/valid.svg" width="15" alt="yes"/> | <img src="../assets/valid.svg" width="15" alt="yes"/>
 [OIDC](/tutorials/oidc.html) | <img src="../assets/valid.svg" width="15" alt="yes"/> | <img src="../assets/valid.svg" width="15" alt="yes"/>
 [Stripe](/tutorials/stripe.html) | <img src="../assets/valid.svg" width="15" alt="yes"/> | <img src="../assets/valid.svg" width="15" alt="yes"/>
-[OIDC](/tutorials/oidc.html) | <img src="../assets/valid.svg" width="15" alt="yes"/> | <img src="../assets/valid.svg" width="15" alt="yes"/>
+
 
 </div>
 


### PR DESCRIPTION
Removed duplicate OIDC tutorial link from the getting started readme.md document

## Information

Type | Breaking change
---|---
**Doc** | **No**

****

## Description
This is a documentation fix for the getting started section in TSed

## Usage example

N/A

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
