### PR TITLE
fix(socketio): modify type of settings to Partial<ServerOptions>

### DIFF
--- a/packages/socketio/src/SocketIOModule.ts
+++ b/packages/socketio/src/SocketIOModule.ts
@@ -15,7 +15,7 @@ export class SocketIOModule implements AfterListen {
   disableRoutesSummary: boolean;
 
   @Constant("socketIO", {})
-  settings: ServerOptions;
+  settings: Partial<ServerOptions>;
 
   @Constant("httpPort")
   httpPort: string | number;

--- a/packages/socketio/src/interfaces/index.ts
+++ b/packages/socketio/src/interfaces/index.ts
@@ -3,7 +3,7 @@ import SocketIO from "socket.io";
 declare global {
   namespace TsED {
     interface Configuration {
-      socketIO: SocketIO.ServerOptions;
+      socketIO: Partial<SocketIO.ServerOptions>;
     }
   }
 }


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Fix | No

****

## Description
- This issue caused in v6.39.1 or above with socket.io@^4.
- In socket.io >= 3.0.0, attach method requires `Partial<ServerOptions>` at the second param.
    - [v3.0.0](https://github.com/socketio/socket.io/blob/3.0.0/lib/index.ts#L335)
    - [v4.0.1(latest)](https://github.com/socketio/socket.io/blob/4.0.1/lib/index.ts#L378)
- However Ts.ED socketio module's configuration type is `ServerOptions`
    - This mandatories to users to specify all required properties of `ServerOptions` in `@Configuration`.
    - ![image](https://user-images.githubusercontent.com/1638767/116824449-4d605d00-abc5-11eb-8d86-4555d457e04a.png)
    - But it is not necessary.


## Note

- I don't know why [the server for test](https://github.com/TypedProject/tsed/blob/production/packages/socketio/test/app/Server.ts#L36) avoids type checking.


## Todos

- [x] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
